### PR TITLE
feat: Support web push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
         <version>1.21.0</version>
       </dependency>
       <dependency>
+        <groupId>com.google.crypto.tink</groupId>
+        <artifactId>apps-webpush</artifactId>
+        <version>1.14.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.redis</groupId>
         <artifactId>testcontainers-redis</artifactId>
         <version>2.2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,11 @@
         <version>${gson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.crypto.tink</groupId>
+        <artifactId>tink</artifactId>
+        <version>1.21.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.redis</groupId>
         <artifactId>testcontainers-redis</artifactId>
         <version>2.2.2</version>

--- a/service/config/sample-secrets-bundle.yml
+++ b/service/config/sample-secrets-bundle.yml
@@ -105,3 +105,11 @@ tlsKeyStore.password: unset
 noiseTunnel.tlsKeyStorePassword: ABCDEFGHIJKLMNOPQRSTUVWXYZ
 noiseTunnel.noiseStaticPrivateKey: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 noiseTunnel.recognizedProxySecret: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789AAAAAAA
+
+# To generate a key: openssl ecparam -name prime256v1 -genkey -noout | openssl pkcs8 -topk8 -outform DER -nocrypt | base64 -w0
+#
+# To get the public key (always starts with \x04): openssl ec -pubout -outform DER | tail -c +27 | basenc --base64url -w0
+#
+# The below private key was generated exclusively for testing purposes. Do not use it in any other context.
+# Associated public key: BOlXVvYRMU_QIIvrChGx0bRKeKWpXs0yiKKyhyrk__GXQY7xP3s3fDtr9vihY2RYq_EnWE3lDvm1lq4LSxcc5Lk
+webPush.vapidStaticPrivateKey: MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8dRIiQwMkW/hdtdytU4NJmQWDjUTOv3ZV/nDQVGHGy2hRANCAATpV1b2ETFP0CCL6woRsdG0SnilqV7NMoiisocq5P/xl0GO8T97N3w7a/b4oWNkWKvxJ1hN5Q75tZauC0sXHOS5

--- a/service/config/sample.yml
+++ b/service/config/sample.yml
@@ -537,6 +537,9 @@ noiseTunnel:
   recognizedProxySecret: secret://noiseTunnel.recognizedProxySecret
 
 webPush:
+  # vapidSub can be an https:// url or a mailto: url
+  # vapidSub: mailto:contact@example.com
+  vapidSub: https://github.com/mollyim/flatline-platform/issues
   vapidStaticPrivateKey: secret://webPush.vapidStaticPrivateKey
 
 externalRequestFilter:

--- a/service/config/sample.yml
+++ b/service/config/sample.yml
@@ -536,6 +536,9 @@ noiseTunnel:
   noiseStaticPrivateKey: secret://noiseTunnel.noiseStaticPrivateKey
   recognizedProxySecret: secret://noiseTunnel.recognizedProxySecret
 
+webPush:
+  vapidStaticPrivateKey: secret://webPush.vapidStaticPrivateKey
+
 externalRequestFilter:
   grpcMethods:
     - com.example.grpc.ExampleService/exampleMethod

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -252,6 +252,10 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsub</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>tink</artifactId>
+    </dependency>
 
     <!-- resolve opentelemetry-semconv conflicts from lower in firebase-admin and firestore dependency trees -->
     <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -256,6 +256,10 @@
       <groupId>com.google.crypto.tink</groupId>
       <artifactId>tink</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.crypto.tink</groupId>
+      <artifactId>apps-webpush</artifactId>
+    </dependency>
 
     <!-- resolve opentelemetry-semconv conflicts from lower in firebase-admin and firestore dependency trees -->
     <dependency>

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerConfiguration.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerConfiguration.java
@@ -65,6 +65,7 @@ import org.whispersystems.textsecuregcm.configuration.TlsKeyStoreConfiguration;
 import org.whispersystems.textsecuregcm.configuration.TurnConfiguration;
 import org.whispersystems.textsecuregcm.configuration.UnidentifiedDeliveryConfiguration;
 import org.whispersystems.textsecuregcm.configuration.VirtualThreadConfiguration;
+import org.whispersystems.textsecuregcm.configuration.WebPushConfiguration;
 import org.whispersystems.textsecuregcm.configuration.ZkConfig;
 import org.whispersystems.websocket.configuration.WebSocketConfiguration;
 
@@ -323,6 +324,11 @@ public class WhisperServerConfiguration extends Configuration {
   @Valid
   @NotNull
   @JsonProperty
+  private WebPushConfiguration webPush;
+
+  @Valid
+  @NotNull
+  @JsonProperty
   private ExternalRequestFilterConfiguration externalRequestFilter;
 
   @Valid
@@ -553,6 +559,10 @@ public class WhisperServerConfiguration extends Configuration {
 
   public NoiseTunnelConfiguration getNoiseTunnelConfiguration() {
     return noiseTunnel;
+  }
+
+  public WebPushConfiguration getWebPushConfiguration() {
+    return webPush;
   }
 
   public ExternalRequestFilterConfiguration getExternalRequestFilterConfiguration() {

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
@@ -683,7 +683,7 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     // FLT(uoemai): Notification providers replaced by dummy logger during development.
     // APNSender apnSender = new APNSender(apnSenderExecutor, config.getApnConfiguration());
     // FcmSender fcmSender = new FcmSender(fcmSenderExecutor, config.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster);
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster, config.getWebPushConfiguration().vapidStaticKeyPair());
     DummySender apnSender = new DummySender("APN");
     DummySender fcmSender = new DummySender("FCM");
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
@@ -501,6 +501,8 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     FaultTolerantRedisClusterClient messagesCluster =
         config.getMessageCacheConfiguration().getRedisClusterConfiguration()
             .build("messages", sharedClientResources.mutate());
+    FaultTolerantRedisClusterClient webPushSenderCluster = config.getPushSchedulerCluster().build("webpush",
+        sharedClientResources.mutate());
     FaultTolerantRedisClusterClient pushSchedulerCluster = config.getPushSchedulerCluster().build("push_scheduler",
         sharedClientResources.mutate());
     FaultTolerantRedisClusterClient rateLimitersCluster = config.getRateLimitersCluster().build("rate_limiters",
@@ -681,7 +683,7 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     // FLT(uoemai): Notification providers replaced by dummy logger during development.
     // APNSender apnSender = new APNSender(apnSenderExecutor, config.getApnConfiguration());
     // FcmSender fcmSender = new FcmSender(fcmSenderExecutor, config.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor);
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster);
     DummySender apnSender = new DummySender("APN");
     DummySender fcmSender = new DummySender("FCM");
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
@@ -683,7 +683,12 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     // FLT(uoemai): Notification providers replaced by dummy logger during development.
     // APNSender apnSender = new APNSender(apnSenderExecutor, config.getApnConfiguration());
     // FcmSender fcmSender = new FcmSender(fcmSenderExecutor, config.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster, config.getWebPushConfiguration().vapidStaticKeyPair());
+    WebPushSender webPushSender = new WebPushSender(
+      webPushSenderExecutor,
+      webPushSenderCluster,
+      config.getWebPushConfiguration().vapidStaticKeyPair(),
+      config.getWebPushConfiguration().vapidSub()
+    );
     DummySender apnSender = new DummySender("APN");
     DummySender fcmSender = new DummySender("FCM");
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
@@ -1143,7 +1143,7 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
         phoneNumberIdentifiers, registrationServiceClient, registrationRecoveryPasswordsManager, registrationRecoveryChecker);
     final List<Object> commonControllers = Lists.newArrayList(
         new AccountController(accountsManager, rateLimiters, registrationRecoveryPasswordsManager,
-            usernameHashZkProofVerifier),
+            usernameHashZkProofVerifier, pushNotificationManager),
         new AccountControllerV2(accountsManager, changeNumberManager, phoneVerificationTokenManager,
             registrationLockVerificationManager, rateLimiters),
         new AttachmentControllerV4(rateLimiters, gcsAttachmentGenerator, tusAttachmentGenerator,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/WhisperServerService.java
@@ -192,6 +192,7 @@ import org.whispersystems.textsecuregcm.push.PushNotificationManager;
 import org.whispersystems.textsecuregcm.push.PushNotificationScheduler;
 import org.whispersystems.textsecuregcm.push.ReceiptSender;
 import org.whispersystems.textsecuregcm.push.RedisMessageAvailabilityManager;
+import org.whispersystems.textsecuregcm.push.WebPushSender;
 import org.whispersystems.textsecuregcm.redis.ConnectionEventLogger;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClient;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
@@ -511,6 +512,7 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     final BlockingQueue<Runnable> receiptSenderQueue = new LinkedBlockingQueue<>();
     Metrics.gaugeCollectionSize(name(getClass(), "receiptSenderQueue"), Collections.emptyList(), receiptSenderQueue);
     final BlockingQueue<Runnable> fcmSenderQueue = new LinkedBlockingQueue<>();
+    final BlockingQueue<Runnable> webPushSenderQueue = new LinkedBlockingQueue<>();
     Metrics.gaugeCollectionSize(name(getClass(), "fcmSenderQueue"), Collections.emptyList(), fcmSenderQueue);
     final BlockingQueue<Runnable> messageDeliveryQueue = new LinkedBlockingQueue<>();
     Metrics.gaugeCollectionSize(MetricsUtil.name(getClass(), "messageDeliveryQueue"), Collections.emptyList(),
@@ -521,6 +523,8 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
         .maxThreads(1).minThreads(1).build();
     ExecutorService fcmSenderExecutor = ExecutorServiceBuilder.of(environment, "fcmSender")
         .maxThreads(32).minThreads(32).workQueue(fcmSenderQueue).build();
+    ExecutorService webPushSenderExecutor = ExecutorServiceBuilder.of(environment, "webPushSender")
+        .maxThreads(32).minThreads(32).workQueue(webPushSenderQueue).build();
     ExecutorService secureValueRecoveryServiceExecutor = ExecutorServiceBuilder.of(environment, "secureValueRecoveryService")
         .maxThreads(1).minThreads(1).build();
     ExecutorService storageServiceExecutor = ExecutorServiceBuilder.of(environment, "storageService")
@@ -677,12 +681,13 @@ public class WhisperServerService extends Application<WhisperServerConfiguration
     // FLT(uoemai): Notification providers replaced by dummy logger during development.
     // APNSender apnSender = new APNSender(apnSenderExecutor, config.getApnConfiguration());
     // FcmSender fcmSender = new FcmSender(fcmSenderExecutor, config.getFcmConfiguration().credentials().value());
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor);
     DummySender apnSender = new DummySender("APN");
     DummySender fcmSender = new DummySender("FCM");
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,
-        apnSender, fcmSender, accountsManager, 0, 0, retryExecutor);
+        apnSender, fcmSender, webPushSender, accountsManager, 0, 0, retryExecutor);
     PushNotificationManager pushNotificationManager =
-        new PushNotificationManager(accountsManager, apnSender, fcmSender, pushNotificationScheduler);
+        new PushNotificationManager(accountsManager, apnSender, fcmSender, webPushSender, pushNotificationScheduler);
     RateLimiters rateLimiters = RateLimiters.create(dynamicConfigurationManager, rateLimitersCluster, retryExecutor);
     // FLT(uoemai): Device provisioning is disabled in the prototype.
     // ProvisioningManager provisioningManager = new ProvisioningManager(pubsubClient);

--- a/service/src/main/java/org/whispersystems/textsecuregcm/configuration/WebPushConfiguration.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/configuration/WebPushConfiguration.java
@@ -15,9 +15,9 @@ import org.whispersystems.textsecuregcm.configuration.secrets.SecretBytes;
 
 import com.google.crypto.tink.internal.EllipticCurvesUtil;
 
-public record WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey, KeyPair keyPair) {
-  public WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey) {
-    this(vapidStaticPrivateKey, null);
+public record WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey, @NotNull String vapidSub, KeyPair keyPair) {
+  public WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey, @NotNull String vapidSub) {
+    this(vapidStaticPrivateKey, vapidSub, null);
   }
 
   public WebPushConfiguration {

--- a/service/src/main/java/org/whispersystems/textsecuregcm/configuration/WebPushConfiguration.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/configuration/WebPushConfiguration.java
@@ -1,0 +1,43 @@
+package org.whispersystems.textsecuregcm.configuration;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+import org.whispersystems.textsecuregcm.configuration.secrets.SecretBytes;
+
+import com.google.crypto.tink.internal.EllipticCurvesUtil;
+
+public record WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey, KeyPair keyPair) {
+  public WebPushConfiguration(@NotNull SecretBytes vapidStaticPrivateKey) {
+    this(vapidStaticPrivateKey, null);
+  }
+
+  public WebPushConfiguration {
+    try {
+      keyPair = genVapidKeyPair(vapidStaticPrivateKey);
+    } catch (GeneralSecurityException e) {}
+  }
+
+  private static KeyPair genVapidKeyPair(SecretBytes vapidStaticPrivateKey) throws GeneralSecurityException {
+    final KeyFactory kf = KeyFactory.getInstance("EC");
+    final ECPrivateKey privkey = (ECPrivateKey) kf.generatePrivate(
+      new PKCS8EncodedKeySpec(vapidStaticPrivateKey.value())
+    );
+    final ECPoint w = EllipticCurvesUtil.multiplyByGenerator(privkey.getS(), privkey.getParams());
+    final ECPublicKeySpec spec = new ECPublicKeySpec(w, privkey.getParams());
+    final ECPublicKey pubkey = (ECPublicKey) kf.generatePublic(spec);
+    return new KeyPair(pubkey, privkey);
+  }
+
+  public KeyPair vapidStaticKeyPair() {
+    return keyPair;
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -56,7 +56,10 @@ import org.whispersystems.textsecuregcm.identity.IdentityType;
 import org.whispersystems.textsecuregcm.identity.ServiceIdentifier;
 import org.whispersystems.textsecuregcm.limits.RateLimitedByIp;
 import org.whispersystems.textsecuregcm.limits.RateLimiters;
+import org.whispersystems.textsecuregcm.push.PushNotificationManager;
+import org.whispersystems.textsecuregcm.push.WebPushActivation;
 import org.whispersystems.textsecuregcm.push.WebPushSubscription;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
@@ -76,6 +79,7 @@ public class AccountController {
   public static final int USERNAME_HASH_LENGTH = 32;
   public static final int MAXIMUM_USERNAME_CIPHERTEXT_LENGTH = 128;
 
+  private final PushNotificationManager pushNotificationManager;
   private final AccountsManager accounts;
   private final RateLimiters rateLimiters;
   private final RegistrationRecoveryPasswordsManager registrationRecoveryPasswordsManager;
@@ -85,11 +89,13 @@ public class AccountController {
       AccountsManager accounts,
       RateLimiters rateLimiters,
       RegistrationRecoveryPasswordsManager registrationRecoveryPasswordsManager,
-      UsernameHashZkProofVerifier usernameHashZkProofVerifier) {
+      UsernameHashZkProofVerifier usernameHashZkProofVerifier,
+      PushNotificationManager pushNotificationManager) {
     this.accounts = accounts;
     this.rateLimiters = rateLimiters;
     this.registrationRecoveryPasswordsManager = registrationRecoveryPasswordsManager;
     this.usernameHashZkProofVerifier = usernameHashZkProofVerifier;
+    this.pushNotificationManager = pushNotificationManager;
   }
 
   @PUT
@@ -112,6 +118,7 @@ public class AccountController {
     accounts.updateDevice(account, device.getId(), d -> {
       d.setApnId(null);
       d.setWebPush(null);
+      d.setWebPushActivation(null);
       d.setGcmId(registrationId.gcmRegistrationId());
       d.setFetchesMessages(false);
     });
@@ -147,14 +154,51 @@ public class AccountController {
     final Device device = account.getDevice(auth.deviceId())
         .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
 
-    if (Objects.equals(device.getWebPush(), webPushSubscription)) {
+    if (Objects.equals(device.getWebPush(), webPushSubscription) && device.getWebPushActivated()) {
       return;
     }
+
+    final WebPushActivation activationToken = WebPushActivation.newToken();
+
+    // We send to the subscription, with activated=true, else it wouldn't be sent
+    pushNotificationManager.sendActivationTokenNotification(new PushToken.WEBPUSH(webPushSubscription, true), activationToken.activationToken());
 
     accounts.updateDevice(account, device.getId(), d -> {
       d.setApnId(null);
       d.setGcmId(null);
       d.setWebPush(webPushSubscription);
+      d.setWebPushActivation(activationToken);
+      d.setFetchesMessages(false);
+    });
+  }
+
+  @PUT
+  @Path("/webpush/activate")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void activateWebPush(@Auth AuthenticatedDevice auth,
+      @NotNull @Valid WebPushActivation webPushActivation) {
+
+    final Account account = accounts.getByAccountIdentifier(auth.accountIdentifier())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    final Device device = account.getDevice(auth.deviceId())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    final String token = webPushActivation.activationToken();
+    final WebPushActivation deviceActivation = device.getWebPushActivation();
+
+    if (
+      device.getWebPush() == null ||
+      token == null ||
+      deviceActivation == null ||
+      !Objects.equals(deviceActivation.activationToken(), token)
+    ) {
+      return;
+    }
+
+    accounts.updateDevice(account, device.getId(), d -> {
+      d.setWebPushActivation(new WebPushActivation(true, null));
       d.setFetchesMessages(false);
     });
   }
@@ -170,6 +214,7 @@ public class AccountController {
 
     accounts.updateDevice(account, device.getId(), d -> {
       d.setWebPush(null);
+      d.setWebPushActivation(null);
       d.setFetchesMessages(false);
       // For now, only Android app can use webpush, desktop may support it later
       d.setUserAgent("OWA");
@@ -195,6 +240,7 @@ public class AccountController {
       d.setApnId(registrationId.apnRegistrationId());
       d.setGcmId(null);
       d.setWebPush(null);
+      d.setWebPushActivation(null);
       d.setFetchesMessages(false);
     });
   }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/AccountController.java
@@ -56,6 +56,7 @@ import org.whispersystems.textsecuregcm.identity.IdentityType;
 import org.whispersystems.textsecuregcm.identity.ServiceIdentifier;
 import org.whispersystems.textsecuregcm.limits.RateLimitedByIp;
 import org.whispersystems.textsecuregcm.limits.RateLimiters;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
@@ -110,6 +111,7 @@ public class AccountController {
 
     accounts.updateDevice(account, device.getId(), d -> {
       d.setApnId(null);
+      d.setWebPush(null);
       d.setGcmId(registrationId.gcmRegistrationId());
       d.setFetchesMessages(false);
     });
@@ -127,6 +129,49 @@ public class AccountController {
     accounts.updateDevice(account, device.getId(), d -> {
       d.setGcmId(null);
       d.setFetchesMessages(false);
+      d.setUserAgent("OWA");
+    });
+  }
+
+
+  @PUT
+  @Path("/webpush/")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void setWebPushSubscription(@Auth AuthenticatedDevice auth,
+      @NotNull @Valid WebPushSubscription webPushSubscription) {
+
+    final Account account = accounts.getByAccountIdentifier(auth.accountIdentifier())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    final Device device = account.getDevice(auth.deviceId())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    if (Objects.equals(device.getWebPush(), webPushSubscription)) {
+      return;
+    }
+
+    accounts.updateDevice(account, device.getId(), d -> {
+      d.setApnId(null);
+      d.setGcmId(null);
+      d.setWebPush(webPushSubscription);
+      d.setFetchesMessages(false);
+    });
+  }
+
+  @DELETE
+  @Path("/webpush/")
+  public void deletewebpushRegistrationId(@Auth AuthenticatedDevice auth) {
+    final Account account = accounts.getByAccountIdentifier(auth.accountIdentifier())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    final Device device = account.getDevice(auth.deviceId())
+        .orElseThrow(() -> new WebApplicationException(Status.UNAUTHORIZED));
+
+    accounts.updateDevice(account, device.getId(), d -> {
+      d.setWebPush(null);
+      d.setFetchesMessages(false);
+      // For now, only Android app can use webpush, desktop may support it later
       d.setUserAgent("OWA");
     });
   }
@@ -149,6 +194,7 @@ public class AccountController {
     accounts.updateDevice(account, device.getId(), d -> {
       d.setApnId(registrationId.apnRegistrationId());
       d.setGcmId(null);
+      d.setWebPush(null);
       d.setFetchesMessages(false);
     });
   }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/controllers/VerificationController.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/controllers/VerificationController.java
@@ -79,6 +79,7 @@ import org.whispersystems.textsecuregcm.mappers.RegistrationServiceSenderExcepti
 import org.whispersystems.textsecuregcm.metrics.UserAgentTagUtil;
 import org.whispersystems.textsecuregcm.push.PushNotification;
 import org.whispersystems.textsecuregcm.push.PushNotificationManager;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.registration.ClientType;
 import org.whispersystems.textsecuregcm.registration.MessageTransport;
 import org.whispersystems.textsecuregcm.registration.RegistrationFraudException;
@@ -338,7 +339,13 @@ public class VerificationController {
         );
       }
 
-      pushNotificationManager.sendRegistrationChallengeNotification(pushTokenAndType.first(), pushTokenAndType.second(),
+      final PushToken<?> token = switch(pushTokenAndType.second()) {
+        case FCM -> new PushToken.FCM(pushTokenAndType.first());
+        case APN -> new PushToken.APN(pushTokenAndType.first());
+        case WEBPUSH -> null;
+      };
+
+      pushNotificationManager.sendRegistrationChallengeNotification(token,
           verificationSession.pushChallenge());
     }
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcService.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.signal.chat.device.ActivatePushTokenRequest;
+import org.signal.chat.device.ActivatePushTokenResponse;
 import org.signal.chat.device.ClearPushTokenRequest;
 import org.signal.chat.device.ClearPushTokenResponse;
 import org.signal.chat.device.GetDevicesRequest;
@@ -35,6 +37,7 @@ import org.signal.chat.device.SetPushTokenResponse;
 import org.whispersystems.textsecuregcm.auth.grpc.AuthenticatedDevice;
 import org.whispersystems.textsecuregcm.auth.grpc.AuthenticationUtil;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.WebPushActivation;
 import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
@@ -217,10 +220,24 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
           final Device device = account.getDevice(authenticatedDevice.deviceId())
               .orElseThrow(Status.UNAUTHENTICATED::asRuntimeException);
 
+          // If this is a new web push registration, or if the web push registration is not yet active => generate a new activation token
+          // Else, if it s the same registration and it's already activated: do nothing
+          @Nullable final WebPushActivation webPushActivation;
+          if (webPush != null) {
+            if (!Objects.equals(device.getWebPush(), webPush) || !device.getWebPushActivated()) {
+              webPushActivation = WebPushActivation.newToken();
+            } else {
+              webPushActivation = device.getWebPushActivation();
+            }
+          } else {
+            webPushActivation = null;
+          }
+
           final boolean tokenUnchanged =
               Objects.equals(device.getApnId(), apnsToken) &&
                   Objects.equals(device.getGcmId(), fcmToken) &&
-                  Objects.equals(device.getWebPush(), webPush);
+                  Objects.equals(device.getWebPush(), webPush) &&
+                  Objects.equals(device.getWebPushActivation(), webPushActivation);
 
           return tokenUnchanged
               ? Mono.empty()
@@ -228,10 +245,34 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
                 d.setApnId(apnsToken);
                 d.setGcmId(fcmToken);
                 d.setWebPush(webPush);
+                d.setWebPushActivation(webPushActivation);
                 d.setFetchesMessages(false);
               }));
         })
         .thenReturn(SetPushTokenResponse.newBuilder().build());
+  }
+
+  @Override
+  public Mono<ActivatePushTokenResponse> activatePushToken(final ActivatePushTokenRequest request) {
+    final AuthenticatedDevice authenticatedDevice = AuthenticationUtil.requireAuthenticatedDevice();
+
+    return Mono.fromFuture(() -> accountsManager.getByAccountIdentifierAsync(authenticatedDevice.accountIdentifier()))
+        .map(maybeAccount -> maybeAccount.orElseThrow(Status.UNAUTHENTICATED::asRuntimeException))
+        .flatMap(account -> Mono.fromFuture(() -> accountsManager.updateDeviceAsync(account, authenticatedDevice.deviceId(), device -> {
+          String token = request.getActivationToken();
+          WebPushActivation deviceActivationToken = device.getWebPushActivation();
+          if (
+            StringUtils.isNotBlank(token) &&
+            device.getWebPush() != null &&
+            deviceActivationToken != null &&
+            Objects.equals(deviceActivationToken.activationToken(), token)
+          ) {
+              device.setWebPushActivation(new WebPushActivation(true, null));
+          }
+
+          device.setFetchesMessages(true);
+        })))
+        .thenReturn(ActivatePushTokenResponse.newBuilder().build());
   }
 
   @Override
@@ -250,6 +291,7 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
           device.setApnId(null);
           device.setGcmId(null);
           device.setWebPush(null);
+          device.setWebPushActivation(null);
           device.setFetchesMessages(true);
         })))
         .thenReturn(ClearPushTokenResponse.newBuilder().build());

--- a/service/src/main/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcService.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcService.java
@@ -6,7 +6,14 @@
 package org.whispersystems.textsecuregcm.grpc;
 
 import com.google.protobuf.ByteString;
+
+import io.dropwizard.jersey.validation.Validators;
 import io.grpc.Status;
+import jakarta.validation.ConstraintViolation;
+
+import java.net.URI;
+import java.security.interfaces.ECPublicKey;
+import java.util.Base64;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,9 +35,12 @@ import org.signal.chat.device.SetPushTokenResponse;
 import org.whispersystems.textsecuregcm.auth.grpc.AuthenticatedDevice;
 import org.whispersystems.textsecuregcm.auth.grpc.AuthenticationUtil;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
 import org.whispersystems.textsecuregcm.storage.DeviceCapability;
+import org.whispersystems.textsecuregcm.util.P256ECPublicKeyAdapter;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -133,6 +143,7 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
 
     @Nullable final String apnsToken;
     @Nullable final String fcmToken;
+    @Nullable final WebPushSubscription webPush;
 
     switch (request.getTokenRequestCase()) {
 
@@ -145,6 +156,7 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
 
         apnsToken = StringUtils.stripToNull(apnsTokenRequest.getApnsToken());
         fcmToken = null;
+        webPush = null;
       }
 
       case FCM_TOKEN_REQUEST -> {
@@ -156,6 +168,44 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
 
         apnsToken = null;
         fcmToken = StringUtils.stripToNull(fcmTokenRequest.getFcmToken());
+        webPush = null;
+      }
+
+      case WEB_PUSH_REQUEST -> {
+        final SetPushTokenRequest.WebPushRequest webPushRequest = request.getWebPushRequest();
+
+        if (StringUtils.isBlank(webPushRequest.getEndpoint())) {
+          throw Status.INVALID_ARGUMENT.withDescription("WebPush endpoint must not be blank").asRuntimeException();
+        }
+        if (StringUtils.isBlank(webPushRequest.getPublicKey())) {
+          throw Status.INVALID_ARGUMENT.withDescription("WebPush publicKey must not be blank").asRuntimeException();
+        }
+        if (StringUtils.isBlank(webPushRequest.getAuth())) {
+          throw Status.INVALID_ARGUMENT.withDescription("WebPush auth must not be blank").asRuntimeException();
+        }
+
+        final Set<ConstraintViolation<WebPushSubscription>> constraintViolations;
+
+        try {
+          URI endpoint = new URI(webPushRequest.getEndpoint());
+          ECPublicKey userPublicKey = P256ECPublicKeyAdapter.Deserializer.deserializePublicKey(
+            webPushRequest.getPublicKey()
+          );
+          byte[] userAuth = Base64.getUrlDecoder().decode(webPushRequest.getAuth());
+
+          webPush = new WebPushSubscription(endpoint, userPublicKey, userAuth);
+
+          constraintViolations = Validators.newValidator().validate(webPush);
+        } catch (Exception e) {
+          throw Status.INVALID_ARGUMENT.withDescription("Cannot parse webpush argument").asRuntimeException();
+        }
+
+        if (!constraintViolations.isEmpty()) {
+          throw Status.INVALID_ARGUMENT.withDescription("WebPush doesn't follow constraints").asRuntimeException();
+        }
+
+        apnsToken = null;
+        fcmToken = null;
       }
 
       default -> throw Status.INVALID_ARGUMENT.withDescription("No tokens specified").asRuntimeException();
@@ -169,13 +219,15 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
 
           final boolean tokenUnchanged =
               Objects.equals(device.getApnId(), apnsToken) &&
-                  Objects.equals(device.getGcmId(), fcmToken);
+                  Objects.equals(device.getGcmId(), fcmToken) &&
+                  Objects.equals(device.getWebPush(), webPush);
 
           return tokenUnchanged
               ? Mono.empty()
               : Mono.fromFuture(() -> accountsManager.updateDeviceAsync(account, authenticatedDevice.deviceId(), d -> {
                 d.setApnId(apnsToken);
                 d.setGcmId(fcmToken);
+                d.setWebPush(webPush);
                 d.setFetchesMessages(false);
               }));
         })
@@ -197,6 +249,7 @@ public class DevicesGrpcService extends ReactorDevicesGrpc.DevicesImplBase {
 
           device.setApnId(null);
           device.setGcmId(null);
+          device.setWebPush(null);
           device.setFetchesMessages(true);
         })))
         .thenReturn(ClearPushTokenResponse.newBuilder().build());

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.lifecycle.Managed;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -27,6 +28,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import org.whispersystems.textsecuregcm.configuration.ApnConfiguration;
+import org.whispersystems.textsecuregcm.push.PushNotification.NotificationType;
+import org.whispersystems.textsecuregcm.push.PushNotification.UnsupportedNotificationType;
 
 public class APNSender implements Managed, PushNotificationSender {
 
@@ -74,31 +77,39 @@ public class APNSender implements Managed, PushNotificationSender {
 
   @Override
   public CompletableFuture<SendPushNotificationResult> sendNotification(final PushNotification notification) {
-    final String payload = switch (notification.notificationType()) {
-      case NOTIFICATION -> notification.urgent() ? APN_NSE_NOTIFICATION_PAYLOAD : APN_BACKGROUND_PAYLOAD;
+    final String payload;
+    final PushType pushType;
+    try {
+     payload = switch (notification.notificationType()) {
+        case NOTIFICATION -> notification.urgent() ? APN_NSE_NOTIFICATION_PAYLOAD : APN_BACKGROUND_PAYLOAD;
 
-      case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> new SimpleApnsPayloadBuilder()
-          .setMutableContent(true)
-          .setLocalizedAlertMessage("APN_Message")
-          .addCustomProperty("attemptLoginContext", notification.data())
-          .build();
+        case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> new SimpleApnsPayloadBuilder()
+            .setMutableContent(true)
+            .setLocalizedAlertMessage("APN_Message")
+            .addCustomProperty("attemptLoginContext", notification.data())
+            .build();
 
-      case CHALLENGE -> new SimpleApnsPayloadBuilder()
-          .setContentAvailable(true)
-          .addCustomProperty("challenge", notification.data())
-          .build();
+        case CHALLENGE -> new SimpleApnsPayloadBuilder()
+            .setContentAvailable(true)
+            .addCustomProperty("challenge", notification.data())
+            .build();
 
-      case RATE_LIMIT_CHALLENGE -> new SimpleApnsPayloadBuilder()
-          .setContentAvailable(true)
-          .addCustomProperty("rateLimitChallenge", notification.data())
-          .build();
-    };
+        case RATE_LIMIT_CHALLENGE -> new SimpleApnsPayloadBuilder()
+            .setContentAvailable(true)
+            .addCustomProperty("rateLimitChallenge", notification.data())
+            .build();
+        case ACTIVATION_TOKEN -> throw new UnsupportedNotificationType(NotificationType.ACTIVATION_TOKEN);
+      };
 
-    final PushType pushType = switch (notification.notificationType()) {
-      case NOTIFICATION -> notification.urgent() ? PushType.ALERT : PushType.BACKGROUND;
-      case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> PushType.ALERT;
-      case CHALLENGE, RATE_LIMIT_CHALLENGE -> PushType.BACKGROUND;
-    };
+      pushType = switch (notification.notificationType()) {
+        case NOTIFICATION -> notification.urgent() ? PushType.ALERT : PushType.BACKGROUND;
+        case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> PushType.ALERT;
+        case CHALLENGE, RATE_LIMIT_CHALLENGE -> PushType.BACKGROUND;
+        case ACTIVATION_TOKEN -> throw new UnsupportedNotificationType(NotificationType.ACTIVATION_TOKEN);
+      };
+    } catch (UnsupportedNotificationType e) {
+      return CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.of(e.getMessage()), false, Optional.empty()));
+    }
 
     final DeliveryPriority deliveryPriority;
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/APNSender.java
@@ -114,7 +114,7 @@ public class APNSender implements Managed, PushNotificationSender {
 
     final Instant start = Instant.now();
 
-    return apnsClient.sendNotification(new SimpleApnsPushNotification(notification.deviceToken(),
+    return apnsClient.sendNotification(new SimpleApnsPushNotification((String) notification.pushToken().value(),
         bundleId,
         payload,
         MAX_EXPIRATION,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.whispersystems.textsecuregcm.push.PushNotification.NotificationType;
+import org.whispersystems.textsecuregcm.push.PushNotification.UnsupportedNotificationType;
 import org.whispersystems.textsecuregcm.util.ExceptionUtils;
 import org.whispersystems.textsecuregcm.util.GoogleApiUtil;
 
@@ -84,12 +86,18 @@ public class FcmSender implements PushNotificationSender {
             .setPriority(pushNotification.urgent() ? AndroidConfig.Priority.HIGH : AndroidConfig.Priority.NORMAL)
             .build());
 
-    final String key = switch (pushNotification.notificationType()) {
-      case NOTIFICATION -> "newMessageAlert";
-      case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> "attemptLoginContext";
-      case CHALLENGE -> "challenge";
-      case RATE_LIMIT_CHALLENGE -> "rateLimitChallenge";
-    };
+    final String key;
+    try {
+      key = switch (pushNotification.notificationType()) {
+        case NOTIFICATION -> "newMessageAlert";
+        case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> "attemptLoginContext";
+        case CHALLENGE -> "challenge";
+        case RATE_LIMIT_CHALLENGE -> "rateLimitChallenge";
+        case ACTIVATION_TOKEN -> throw new UnsupportedNotificationType(NotificationType.ACTIVATION_TOKEN);
+      };
+    } catch (UnsupportedNotificationType e) {
+      return CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.of(e.getMessage()), false, Optional.empty()));
+    }
 
     builder.putData(key, pushNotification.data() != null ? pushNotification.data() : "");
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/FcmSender.java
@@ -79,7 +79,7 @@ public class FcmSender implements PushNotificationSender {
   @Override
   public CompletableFuture<SendPushNotificationResult> sendNotification(PushNotification pushNotification) {
     Message.Builder builder = Message.builder()
-        .setToken(pushNotification.deviceToken())
+        .setToken((String) pushNotification.pushToken().value())
         .setAndroidConfig(AndroidConfig.builder()
             .setPriority(pushNotification.urgent() ? AndroidConfig.Priority.HIGH : AndroidConfig.Priority.NORMAL)
             .build());

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotification.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotification.java
@@ -5,12 +5,12 @@
 
 package org.whispersystems.textsecuregcm.push;
 
+import org.apache.commons.lang3.StringUtils;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.Device;
 import javax.annotation.Nullable;
 
-public record PushNotification(String deviceToken,
-                               TokenType tokenType,
+public record PushNotification(PushToken<?> pushToken,
                                NotificationType notificationType,
                                @Nullable String data,
                                @Nullable Account destination,
@@ -25,7 +25,35 @@ public record PushNotification(String deviceToken,
   }
 
   public enum TokenType {
+    WEBPUSH,
     FCM,
     APN
+  }
+
+  public sealed interface PushToken<T> permits PushToken.FCM, PushToken.APN, PushToken.WEBPUSH {
+    T value();
+    TokenType type();
+
+    default boolean isBlank() {
+      if (value() == null) return true;
+      return switch(value()) {
+        case String s -> StringUtils.isBlank(s);
+        default -> false;
+      };
+    }
+
+    public record FCM(String value) implements PushToken<String> {
+      public TokenType type() { return TokenType.FCM; }
+    }
+    public record APN(String value) implements PushToken<String> {
+      public TokenType type() { return TokenType.APN; }
+    }
+    public record WEBPUSH(WebPushSubscription value) implements PushToken<WebPushSubscription> {
+      public TokenType type() { return TokenType.WEBPUSH; }
+    }
+  }
+
+  public TokenType tokenType() {
+    return pushToken().type();
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotification.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotification.java
@@ -17,10 +17,17 @@ public record PushNotification(PushToken<?> pushToken,
                                @Nullable Device destinationDevice,
                                boolean urgent) {
 
+  static public class UnsupportedNotificationType extends Exception{
+    public UnsupportedNotificationType(NotificationType type) {
+      super("Unsupported push type: " + type.name());
+    }
+  }
+
   public enum NotificationType {
     NOTIFICATION,
     ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY,
     CHALLENGE,
+    ACTIVATION_TOKEN,
     RATE_LIMIT_CHALLENGE
   }
 
@@ -48,7 +55,7 @@ public record PushNotification(PushToken<?> pushToken,
     public record APN(String value) implements PushToken<String> {
       public TokenType type() { return TokenType.APN; }
     }
-    public record WEBPUSH(WebPushSubscription value) implements PushToken<WebPushSubscription> {
+    public record WEBPUSH(WebPushSubscription value, boolean activated) implements PushToken<WebPushSubscription> {
       public TokenType type() { return TokenType.WEBPUSH; }
     }
   }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
@@ -55,6 +55,12 @@ public class PushNotificationManager {
         PushNotification.NotificationType.NOTIFICATION, null, destination, device, urgent));
   }
 
+  /** To activate web push subscription */
+  public CompletableFuture<SendPushNotificationResult> sendActivationTokenNotification(final PushNotification.PushToken<?> deviceToken, final String token) {
+    return sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.ACTIVATION_TOKEN, token, null, null, true))
+        .thenApply(maybeResponse -> maybeResponse.orElseThrow(() -> new AssertionError("Responses must be present for urgent notifications")));
+  }
+
   public CompletableFuture<SendPushNotificationResult> sendRegistrationChallengeNotification(final PushNotification.PushToken<?> deviceToken, final String challengeToken) {
     return sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.CHALLENGE, challengeToken, null, null, true))
         .thenApply(maybeResponse -> maybeResponse.orElseThrow(() -> new AssertionError("Responses must be present for urgent notifications")));
@@ -185,7 +191,10 @@ public class PushNotificationManager {
               // Don't clear the token if it's already changed
               if (originalToken.equals(Device.getPushToken(d, tokenType))) {
                 switch (tokenType) {
-                  case WEBPUSH -> d.setWebPush(null);
+                  case WEBPUSH -> {
+                    d.setWebPush(null);
+                    d.setWebPushActivation(null);
+                  }
                   case FCM -> d.setGcmId(null);
                   case APN -> d.setApnId(null);
                 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationManager.java
@@ -14,19 +14,18 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
-import org.whispersystems.textsecuregcm.util.Pair;
 
 public class PushNotificationManager {
 
   private final AccountsManager accountsManager;
   private final PushNotificationSender apnSender;
   private final PushNotificationSender fcmSender;
+  private final PushNotificationSender webPushSender;
   private final PushNotificationScheduler pushNotificationScheduler;
 
   private static final String SENT_NOTIFICATION_COUNTER_NAME = name(PushNotificationManager.class, "sentPushNotification");
@@ -38,24 +37,26 @@ public class PushNotificationManager {
   public PushNotificationManager(final AccountsManager accountsManager,
       final PushNotificationSender apnSender,
       final PushNotificationSender fcmSender,
+      final PushNotificationSender webPushSender,
       final PushNotificationScheduler pushNotificationScheduler) {
 
     this.accountsManager = accountsManager;
     this.apnSender = apnSender;
     this.fcmSender = fcmSender;
+    this.webPushSender = webPushSender;
     this.pushNotificationScheduler = pushNotificationScheduler;
   }
 
   public CompletableFuture<Optional<SendPushNotificationResult>> sendNewMessageNotification(final Account destination, final byte destinationDeviceId, final boolean urgent) throws NotPushRegisteredException {
     final Device device = destination.getDevice(destinationDeviceId).orElseThrow(NotPushRegisteredException::new);
-    final Pair<String, PushNotification.TokenType> tokenAndType = getToken(device);
+    final PushNotification.PushToken<?> token = Device.getPushToken(device);
 
-    return sendNotification(new PushNotification(tokenAndType.first(), tokenAndType.second(),
+    return sendNotification(new PushNotification(token,
         PushNotification.NotificationType.NOTIFICATION, null, destination, device, urgent));
   }
 
-  public CompletableFuture<SendPushNotificationResult> sendRegistrationChallengeNotification(final String deviceToken, final PushNotification.TokenType tokenType, final String challengeToken) {
-    return sendNotification(new PushNotification(deviceToken, tokenType, PushNotification.NotificationType.CHALLENGE, challengeToken, null, null, true))
+  public CompletableFuture<SendPushNotificationResult> sendRegistrationChallengeNotification(final PushNotification.PushToken<?> deviceToken, final String challengeToken) {
+    return sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.CHALLENGE, challengeToken, null, null, true))
         .thenApply(maybeResponse -> maybeResponse.orElseThrow(() -> new AssertionError("Responses must be present for urgent notifications")));
   }
 
@@ -63,18 +64,17 @@ public class PushNotificationManager {
       throws NotPushRegisteredException {
 
     final Device device = destination.getPrimaryDevice();
-    final Pair<String, PushNotification.TokenType> tokenAndType = getToken(device);
+    final PushNotification.PushToken<?> token = Device.getPushToken(device);
 
-    return sendNotification(new PushNotification(tokenAndType.first(), tokenAndType.second(),
+    return sendNotification(new PushNotification(token,
         PushNotification.NotificationType.RATE_LIMIT_CHALLENGE, challengeToken, destination, device, true))
         .thenApply(maybeResponse -> maybeResponse.orElseThrow(() -> new AssertionError("Responses must be present for urgent notifications")));
   }
 
   public CompletableFuture<SendPushNotificationResult> sendAttemptLoginNotification(final Account destination, final String context) throws NotPushRegisteredException {
     final Device device = destination.getDevice(Device.PRIMARY_ID).orElseThrow(NotPushRegisteredException::new);
-    final Pair<String, PushNotification.TokenType> tokenAndType = getToken(device);
-
-    return sendNotification(new PushNotification(tokenAndType.first(), tokenAndType.second(),
+    final PushNotification.PushToken<?> token = Device.getPushToken(device);
+    return sendNotification(new PushNotification(token,
         PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY,
         context, destination, device, true))
         .thenApply(maybeResponse -> maybeResponse.orElseThrow(() -> new AssertionError("Responses must be present for urgent notifications")));
@@ -82,21 +82,6 @@ public class PushNotificationManager {
 
   public void handleMessagesRetrieved(final Account account, final Device device, final String userAgent) {
     pushNotificationScheduler.cancelScheduledNotifications(account, device).whenComplete(logErrors());
-  }
-
-  @VisibleForTesting
-  Pair<String, PushNotification.TokenType> getToken(final Device device) throws NotPushRegisteredException {
-    final Pair<String, PushNotification.TokenType> tokenAndType;
-
-    if (StringUtils.isNotBlank(device.getGcmId())) {
-      tokenAndType = new Pair<>(device.getGcmId(), PushNotification.TokenType.FCM);
-    } else if (StringUtils.isNotBlank(device.getApnId())) {
-      tokenAndType = new Pair<>(device.getApnId(), PushNotification.TokenType.APN);
-    } else {
-      throw new NotPushRegisteredException();
-    }
-
-    return tokenAndType;
   }
 
   @VisibleForTesting
@@ -114,6 +99,7 @@ public class PushNotificationManager {
     final PushNotificationSender sender = switch (pushNotification.tokenType()) {
       case FCM -> fcmSender;
       case APN -> apnSender;
+      case WEBPUSH -> webPushSender;
     };
 
     return sender.sendNotification(pushNotification).whenComplete((result, throwable) -> {
@@ -141,7 +127,7 @@ public class PushNotificationManager {
         }
       } else {
         logger.debug("Failed to deliver {} push notification to {} ({})",
-            pushNotification.notificationType(), pushNotification.deviceToken(), pushNotification.tokenType(),
+            pushNotification.notificationType(), pushNotification.pushToken(), pushNotification.tokenType(),
             throwable);
 
         Metrics.counter(FAILED_NOTIFICATION_COUNTER_NAME, "cause", throwable.getClass().getSimpleName()).increment();
@@ -184,9 +170,9 @@ public class PushNotificationManager {
   }
 
   private void clearPushToken(final Account account, final Device device, final PushNotification.TokenType tokenType) {
-    final String originalToken = getPushToken(device, tokenType);
+    final PushNotification.PushToken<?> originalToken = Device.getPushToken(device, tokenType);
 
-    if (originalToken == null) {
+    if (originalToken.isBlank()) {
       return;
     }
 
@@ -197,19 +183,13 @@ public class PushNotificationManager {
         rereadAccount.getDevice(device.getId()).ifPresent(rereadDevice ->
             accountsManager.updateDevice(rereadAccount, device.getId(), d -> {
               // Don't clear the token if it's already changed
-              if (originalToken.equals(getPushToken(d, tokenType))) {
+              if (originalToken.equals(Device.getPushToken(d, tokenType))) {
                 switch (tokenType) {
+                  case WEBPUSH -> d.setWebPush(null);
                   case FCM -> d.setGcmId(null);
                   case APN -> d.setApnId(null);
                 }
               }
             })));
-  }
-
-  private static String getPushToken(final Device device, final PushNotification.TokenType tokenType) {
-    return switch (tokenType) {
-      case FCM -> device.getGcmId();
-      case APN -> device.getApnId();
-    };
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationScheduler.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/PushNotificationScheduler.java
@@ -30,6 +30,7 @@ import java.util.function.BiFunction;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.redis.ClusterLuaScript;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
 import org.whispersystems.textsecuregcm.storage.Account;
@@ -47,6 +48,7 @@ public class PushNotificationScheduler implements Managed {
 
   private static final String PENDING_BACKGROUND_APN_NOTIFICATIONS_KEY_PREFIX = "PENDING_BACKGROUND_APN";
   private static final String PENDING_BACKGROUND_FCM_NOTIFICATIONS_KEY_PREFIX = "PENDING_BACKGROUND_FCM";
+  private static final String PENDING_BACKGROUND_WEBPUSH_NOTIFICATIONS_KEY_PREFIX = "PENDING_BACKGROUND_WEBPUSH";
   private static final String LAST_BACKGROUND_NOTIFICATION_TIMESTAMP_KEY_PREFIX = "LAST_BACKGROUND_NOTIFICATION";
   private static final String PENDING_DELAYED_NOTIFICATIONS_KEY_PREFIX = "DELAYED";
 
@@ -65,6 +67,7 @@ public class PushNotificationScheduler implements Managed {
 
   private final PushNotificationSender apnSender;
   private final PushNotificationSender fcmSender;
+  private final PushNotificationSender webPushSender;
   private final AccountsManager accountsManager;
   private final FaultTolerantRedisClusterClient pushSchedulingCluster;
   private final ScheduledExecutorService retryExecutor;
@@ -157,6 +160,7 @@ public class PushNotificationScheduler implements Managed {
   public PushNotificationScheduler(final FaultTolerantRedisClusterClient pushSchedulingCluster,
       final PushNotificationSender apnSender,
       final PushNotificationSender fcmSender,
+      final PushNotificationSender webPushSender,
       final AccountsManager accountsManager,
       final int dedicatedProcessWorkerThreadCount,
       final int workerMaxConcurrency,
@@ -165,6 +169,7 @@ public class PushNotificationScheduler implements Managed {
     this(pushSchedulingCluster,
         apnSender,
         fcmSender,
+        webPushSender,
         accountsManager,
         Clock.systemUTC(),
         dedicatedProcessWorkerThreadCount,
@@ -176,6 +181,7 @@ public class PushNotificationScheduler implements Managed {
   PushNotificationScheduler(final FaultTolerantRedisClusterClient pushSchedulingCluster,
       final PushNotificationSender apnSender,
       final PushNotificationSender fcmSender,
+      final PushNotificationSender webPushSender,
       final AccountsManager accountsManager,
       final Clock clock,
       final int dedicatedProcessThreadCount,
@@ -184,6 +190,7 @@ public class PushNotificationScheduler implements Managed {
 
     this.apnSender = apnSender;
     this.fcmSender = fcmSender;
+    this.webPushSender = webPushSender;
     this.accountsManager = accountsManager;
     this.pushSchedulingCluster = pushSchedulingCluster;
     this.clock = clock;
@@ -207,7 +214,8 @@ public class PushNotificationScheduler implements Managed {
    * @throws IllegalArgumentException if the given device does not have a push token
    */
   public CompletionStage<Void> scheduleBackgroundNotification(final PushNotification.TokenType tokenType, final Account account, final Device device) {
-    if (StringUtils.isBlank(getPushToken(tokenType, device))) {
+    final PushToken<?> pushToken = Device.getPushToken(device, tokenType);
+    if (pushToken.isBlank()) {
       throw new IllegalArgumentException("Device must have an " + tokenType + " token");
     }
     Metrics.counter(BACKGROUND_NOTIFICATION_SCHEDULED_COUNTER_NAME, "type", tokenType.name()).increment();
@@ -296,14 +304,15 @@ public class PushNotificationScheduler implements Managed {
 
   @VisibleForTesting
   CompletableFuture<Void> sendBackgroundNotification(PushNotification.TokenType tokenType, final Account account, final Device device) {
-    final String pushToken = getPushToken(tokenType, device);
-    if (StringUtils.isBlank(pushToken)) {
+    final PushToken<?> pushToken = Device.getPushToken(device, tokenType);
+    if (pushToken.isBlank()) {
       return CompletableFuture.completedFuture(null);
     }
 
     final PushNotificationSender sender = switch (tokenType) {
       case FCM -> fcmSender;
       case APN -> apnSender;
+      case WEBPUSH -> webPushSender;
     };
 
     // It's okay for the "last notification" timestamp to expire after the "cooldown" period has elapsed; a missing
@@ -311,7 +320,7 @@ public class PushNotificationScheduler implements Managed {
     return pushSchedulingCluster.withCluster(connection -> connection.async().set(
         getLastBackgroundNotificationTimestampKey(account, device),
         String.valueOf(clock.millis()), new SetArgs().ex(BACKGROUND_NOTIFICATION_PERIOD)))
-        .thenCompose(ignored -> sender.sendNotification(new PushNotification(pushToken, tokenType, PushNotification.NotificationType.NOTIFICATION, null, account, device, false)))
+        .thenCompose(ignored -> sender.sendNotification(new PushNotification(pushToken, PushNotification.NotificationType.NOTIFICATION, null, account, device, false)))
         .thenAccept(response -> Metrics.counter(BACKGROUND_NOTIFICATION_SENT_COUNTER_NAME,
                 ACCEPTED_TAG, String.valueOf(response.accepted()))
             .increment())
@@ -320,22 +329,26 @@ public class PushNotificationScheduler implements Managed {
 
   @VisibleForTesting
   CompletableFuture<Void> sendDelayedNotification(final Account account, final Device device) {
-    if (StringUtils.isAllBlank(device.getApnId(), device.getGcmId())) {
+    final PushToken<?> pushToken;
+    try {
+      pushToken = Device.getPushToken(device);
+    } catch (NotPushRegisteredException e) {
       return CompletableFuture.completedFuture(null);
     }
 
-    final boolean isApnsDevice = StringUtils.isNotBlank(device.getApnId());
-
     final PushNotification pushNotification = new PushNotification(
-        isApnsDevice ? device.getApnId() : device.getGcmId(),
-        isApnsDevice ? PushNotification.TokenType.APN : PushNotification.TokenType.FCM,
+        pushToken,
         PushNotification.NotificationType.NOTIFICATION,
         null,
         account,
         device,
         true);
 
-    final PushNotificationSender pushNotificationSender = isApnsDevice ? apnSender : fcmSender;
+    final PushNotificationSender pushNotificationSender = switch(pushToken.type()) {
+      case PushNotification.TokenType.FCM -> fcmSender;
+      case PushNotification.TokenType.APN -> apnSender;
+      case PushNotification.TokenType.WEBPUSH -> webPushSender;
+    };
 
     return pushNotificationSender.sendNotification(pushNotification)
         .thenAccept(response -> Metrics.counter(DELAYED_NOTIFICATION_SENT_COUNTER_NAME,
@@ -388,6 +401,7 @@ public class PushNotificationScheduler implements Managed {
     final String prefix = switch (tokenType) {
       case APN -> PENDING_BACKGROUND_APN_NOTIFICATIONS_KEY_PREFIX;
       case FCM -> PENDING_BACKGROUND_FCM_NOTIFICATIONS_KEY_PREFIX;
+      case WEBPUSH -> PENDING_BACKGROUND_WEBPUSH_NOTIFICATIONS_KEY_PREFIX;
     };
     return prefix + "::{" + RedisClusterUtil.getMinimalHashTag(slot) + "}";
   }
@@ -439,12 +453,5 @@ public class PushNotificationScheduler implements Managed {
     } else {
       return "unknown";
     }
-  }
-
-  private static String getPushToken(final PushNotification.TokenType tokenType, final Device device) {
-    return switch (tokenType) {
-      case FCM -> device.getGcmId();
-      case APN -> device.getApnId();
-    };
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushActivation.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushActivation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013-2022 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.push;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record WebPushActivation(
+                                @JsonProperty
+                                boolean activated,
+                                @JsonProperty
+                                String activationToken) {
+  public static WebPushActivation newToken() {
+    return new WebPushActivation(
+      false,
+      UUID.randomUUID().toString()
+    );
+  }                              
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -11,8 +11,14 @@ import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -28,17 +34,23 @@ import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
 import org.whispersystems.textsecuregcm.util.ResilienceUtil;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HttpHeaders;
 import com.google.crypto.tink.apps.webpush.WebPushHybridEncrypt;
+import com.google.crypto.tink.subtle.EllipticCurves;
 
 import io.lettuce.core.SetArgs;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
+import net.logstash.logback.util.StringUtils;
 
 public class WebPushSender implements PushNotificationSender {
 
+  private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
   private final FaultTolerantHttpClient httpClient;
+  private final FaultTolerantRedisClusterClient redisClient;
+  private final KeyPair vapidKp;
 
   private static final Timer SEND_NOTIFICATION_TIMER = Metrics.timer(name(WebPushSender.class, "sendNotification"));
   private static final String RETRY_NAME = ResilienceUtil.name(WebPushSender.class);
@@ -52,23 +64,21 @@ public class WebPushSender implements PushNotificationSender {
    */
   private static final int DEFAULT_RETRY_AFTER = 300;
 
-  private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
-  private final FaultTolerantRedisClusterClient redisClient;
-
   private class RateLimitedException extends Exception {}
 
-  // TODO: Add keystore for the VAPID key
-  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient) throws IOException {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp) throws IOException {
     this.httpClient = FaultTolerantHttpClient.newBuilder("webpush", executor)
       .withRedirect(HttpClient.Redirect.NEVER)
       .build();
     this.redisClient = redisClient;
+    this.vapidKp = vapidKp;
   }
 
   @VisibleForTesting
-  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, FaultTolerantHttpClient httpClient) {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp, FaultTolerantHttpClient httpClient) {
     this.httpClient = httpClient;
     this.redisClient = redisClient;
+    this.vapidKp = vapidKp;
   }
 
   @Override
@@ -83,6 +93,18 @@ public class WebPushSender implements PushNotificationSender {
       return CompletableFuture.completedFuture(
         new SendPushNotificationResult(false, Optional.of("Rate limited"), false, Optional.empty())
       );
+    }
+
+    if (StringUtils.isBlank(authorization)) {
+      try {
+        authorization = genAuthorization(vapidKp, aud, "mailto:TODO@localhost");
+      } catch (Exception e) {
+        logger.warn("Error while making vapid authorization", e);
+        return CompletableFuture.completedFuture(
+          new SendPushNotificationResult(false, Optional.of("Cannot make VAPID auth"), false, Optional.empty())
+        );
+      }
+      cacheAuthorization(aud, authorization);
     }
 
     final Map<String, String> map = new HashMap<String, String>();
@@ -122,7 +144,8 @@ public class WebPushSender implements PushNotificationSender {
       .header("TTL", "604800")
       .header(HttpHeaders.CONTENT_ENCODING, "aes128gcm")
       // The urgency is defined by RFC8030: https://www.rfc-editor.org/info/rfc8030/#section-5.3
-      .header("Urgency", pushNotification.urgent() ? "high" : "normal");
+      .header("Urgency", pushNotification.urgent() ? "high" : "normal")
+      .header("Authorization", authorization);
 
     // The Topic header is defined by webpush to permit the
     // application server (us) to update a notification, to
@@ -182,5 +205,72 @@ public class WebPushSender implements PushNotificationSender {
     .executeSupplier(() ->
       redisClient.withCluster(cluster -> cluster.sync().set(aud, RATE_LIMITED, args))
     );
+  }
+
+  private void cacheAuthorization(final String aud, final String authHeader) {
+    // NX: only set the value if the key doesn't already exists
+    // to be sure we never override a RATE_LIMITED
+    final SetArgs args = new SetArgs().ex(AUTH_CACHE_DURATION).nx();
+    ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
+    .executeSupplier(() ->
+      redisClient.withCluster(cluster -> cluster.sync().set(aud, authHeader, args))
+    );
+  }
+
+  private static String genAuthorization(final KeyPair kp, final String aud, final String sub) throws JsonProcessingException, GeneralSecurityException {
+    return genAuthorization(kp, aud, sub, (int) (System.currentTimeMillis() / 1000));
+  }
+
+  @VisibleForTesting
+  static String genAuthorization(final KeyPair kp, final String aud, final String sub, final int currentTimeSec) throws JsonProcessingException, GeneralSecurityException {
+    final Map<String, String> headerMap = new HashMap<String, String>();
+    headerMap.put("alg", "ES256");
+    headerMap.put("typ", "JWT");
+    final byte[] header = Base64.getUrlEncoder().withoutPadding().encode(
+      SystemMapper.jsonMapper().writeValueAsString(headerMap).getBytes()
+    );
+
+    // The header expire after 15 min
+    final int exp = currentTimeSec + 900;
+    final Map<String, Object> bodyMap = new HashMap<String, Object>();
+    bodyMap.put("aud", aud);
+    bodyMap.put("exp", exp);
+    bodyMap.put("sub", sub);
+    final byte[] body = Base64.getUrlEncoder().withoutPadding().encode(
+      SystemMapper.jsonMapper().writeValueAsString(bodyMap).getBytes()
+    );
+
+    final byte[] toSign = ByteBuffer.allocate(header.length + body.length + 1)
+      .put(header)
+      .put((byte) '.')
+      .put(body)
+      .array();
+
+    final byte[] signature = Base64.getUrlEncoder().withoutPadding().encode(
+      sign(kp, toSign)
+    );
+    final String jwt = new String(
+      ByteBuffer.allocate(toSign.length + signature.length + 1)
+        .put(toSign)
+        .put((byte) '.')
+        .put(signature)
+        .array()
+    );
+    final String k = Base64.getUrlEncoder().withoutPadding().encodeToString(
+      EllipticCurves.pointEncode(
+        EllipticCurves.CurveType.NIST_P256,
+        EllipticCurves.PointFormatType.UNCOMPRESSED,
+        ((ECPublicKey) kp.getPublic()).getW()
+      )
+    );
+    return String.format("vapid t=%s,k=%s", jwt, k);
+  }
+
+  private static byte[] sign(final KeyPair kp, final byte[] data) throws GeneralSecurityException {
+    final Signature engine = Signature.getInstance("SHA256withECDSA");
+    engine.initSign(kp.getPrivate());
+    engine.update(data);
+    byte[] signature = engine.sign();
+    return EllipticCurves.ecdsaDer2Ieee(signature, 64);
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2013-2022 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.push;
+
+import static org.whispersystems.textsecuregcm.metrics.MetricsUtil.name;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HttpHeaders;
+import com.google.crypto.tink.apps.webpush.WebPushHybridEncrypt;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
+import org.whispersystems.textsecuregcm.util.SystemMapper;
+
+public class WebPushSender implements PushNotificationSender {
+
+  private final FaultTolerantHttpClient httpClient;
+
+  private static final Timer SEND_NOTIFICATION_TIMER = Metrics.timer(name(WebPushSender.class, "sendNotification"));
+
+  private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
+
+  // TODO: Add keystore for the VAPID key
+  public WebPushSender (ExecutorService executor) throws IOException {
+    this.httpClient = FaultTolerantHttpClient.newBuilder("webpush", executor)
+      .withRedirect(HttpClient.Redirect.NEVER)
+      .build();
+  }
+
+  @VisibleForTesting
+  public WebPushSender (ExecutorService executor, FaultTolerantHttpClient httpClient) {
+    this.httpClient = httpClient;
+  }
+
+  @Override
+  public CompletableFuture<SendPushNotificationResult> sendNotification(PushNotification pushNotification) {
+    final Map<String, String> map = new HashMap<String, String>();
+
+    final String key = switch (pushNotification.notificationType()) {
+      case NOTIFICATION -> "newMessageAlert";
+      case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> "attemptLoginContext";
+      case CHALLENGE -> "challenge";
+      case RATE_LIMIT_CHALLENGE -> "rateLimitChallenge";
+    };
+
+    map.put(key, pushNotification.data() != null ? pushNotification.data() : "");
+    map.put("urgency", pushNotification.urgent() ? "high" : "low");
+
+    final WebPushSubscription sub = (WebPushSubscription) pushNotification.pushToken().value();
+    final byte[] body;
+    try {
+      final WebPushHybridEncrypt engine = new WebPushHybridEncrypt.Builder()
+        .withAuthSecret(sub.userAuth())
+        .withRecipientPublicKey(sub.userPublicKey())
+        .build();
+
+      final String clearBody = SystemMapper.jsonMapper().writeValueAsString(map);
+      body = engine.encrypt(clearBody.getBytes(), null);
+    } catch (Exception e) {
+      logger.warn("Error while encrypting web push notification", e);
+      return CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.of("Error while encrypting notification"), false, Optional.empty()));
+    }
+
+
+    final Timer.Sample sample = Timer.start();
+
+    final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+      .uri(sub.endpoint())
+      .method("POST", HttpRequest.BodyPublishers.ofByteArray(body))
+      .header(HttpHeaders.CONTENT_TYPE, "application/octet-stream")
+      // We tell the push server to store the push notification at most 7 days, if the user agent
+      // doesn't fetch the notification
+      .header("TTL", "604800")
+      .header(HttpHeaders.CONTENT_ENCODING, "aes128gcm")
+      // The urgency is defined by RFC8030: https://www.rfc-editor.org/info/rfc8030/#section-5.3
+      .header("Urgency", pushNotification.urgent() ? "high" : "normal");
+
+    // The Topic header is defined by webpush to permit the
+    // application server (us) to update a notification, to
+    // avoid to store multiple times a same notification if it
+    // hasn't been received by the user agent yet.
+    //
+    // So, if the notification doesn't contain any data, the push server
+    // don't need to store all of them => we add a topic.
+    //
+    // https://www.rfc-editor.org/info/rfc8030/#section-5.4
+    if (pushNotification.data() == null) {
+      requestBuilder.header("Topic", key);
+    }
+
+    return httpClient.sendAsync(requestBuilder.build(), HttpResponse.BodyHandlers.ofByteArray()).whenComplete((ignored, throwable) -> sample.stop(SEND_NOTIFICATION_TIMER))
+      .thenApply(response -> {
+        int code = response.statusCode();
+        return switch (Integer.valueOf(code)) {
+           case Integer s when s >= 200 && s < 300 ->
+               new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty());
+           case 404, 403, 401, 410 ->
+               new SendPushNotificationResult(false, Optional.of(String.valueOf(code)), true, Optional.of(Instant.now()));
+           // TODO: Handle Too many requests (429)
+           // case 429 -> ;
+           default ->
+               new SendPushNotificationResult(false, Optional.of(String.valueOf(code)), false, Optional.empty());
+        };
+       });
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -8,6 +8,7 @@ package org.whispersystems.textsecuregcm.push;
 import static org.whispersystems.textsecuregcm.metrics.MetricsUtil.name;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -27,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.annotation.Nullable;
 
+import org.signal.libsignal.protocol.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
@@ -42,6 +44,7 @@ import com.google.crypto.tink.apps.webpush.WebPushHybridEncrypt;
 import com.google.crypto.tink.subtle.EllipticCurves;
 
 import io.lettuce.core.SetArgs;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import net.logstash.logback.util.StringUtils;
@@ -100,7 +103,7 @@ public class WebPushSender implements PushNotificationSender {
 
     String authorization;
     try {
-      authorization = getCachedAuthorization(aud);
+      authorization = getCachedAuthorization(aud, sub.endpoint());
     } catch (RateLimitedException e) {
       return CompletableFuture.completedFuture(
         new SendPushNotificationResult(false, Optional.of("Rate limited"), false, Optional.empty())
@@ -188,7 +191,7 @@ public class WebPushSender implements PushNotificationSender {
              } catch (NumberFormatException e) {
                retryAfterS = DEFAULT_RETRY_AFTER;
              }
-             cacheRateLimit(aud, retryAfterS);
+             cacheRateLimit(sub.endpoint(), retryAfterS);
              yield new SendPushNotificationResult(false, Optional.of("Rate limited"), false, Optional.empty());
            }
            default ->
@@ -198,35 +201,53 @@ public class WebPushSender implements PushNotificationSender {
   }
 
   /**
+   * Key to cache rate limited endpoints
+   */
+  private static String rateLimitKey(final String endpoint) {
+    return "WebPush::RateLimit::" + endpoint;
+  }
+
+  /**
+   * Key to cache VAPID header for push servers
+   */
+  private static String headerKey(final String aud) {
+    return "WebPush::Auth::" + aud;
+  }
+
+  /**
    * @throws RateLimitedException if the aud server previously returned a 429 (Too Many Requests)
    * @return the cached authorization header
    */
-  private @Nullable String getCachedAuthorization(final String aud) throws RateLimitedException {
-    final String cached = ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
+  private @Nullable String getCachedAuthorization(final String aud, final URI endpoint) throws RateLimitedException {
+    final Pair<String, String> cached = ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
     .executeSupplier(() ->
-      redisClient.withCluster(cluster -> cluster.sync().get(aud))
+      redisClient.withCluster(cluster -> {
+        RedisAdvancedClusterCommands<String, String> cmd = cluster.sync();
+        String rateLimited = cmd.get(rateLimitKey(endpoint.toString()));
+        String cachedHeader = cmd.get(headerKey(aud));
+        return new Pair<String, String>(rateLimited, cachedHeader);
+      })
     );
-    if (cached == RATE_LIMITED) {
+    if (cached.first() == RATE_LIMITED) {
       throw new RateLimitedException();
     }
-    return cached;
+    return cached.second();
   }
 
-  private void cacheRateLimit(final String aud, final int retryAfterS) {
+  private void cacheRateLimit(final URI endpoint, final int retryAfterS) {
     final SetArgs args = new SetArgs().ex(retryAfterS);
     ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
     .executeSupplier(() ->
-      redisClient.withCluster(cluster -> cluster.sync().set(aud, RATE_LIMITED, args))
+      redisClient.withCluster(cluster -> cluster.sync().set(rateLimitKey(endpoint.toString()), RATE_LIMITED, args))
     );
   }
 
   private void cacheAuthorization(final String aud, final String authHeader) {
     // NX: only set the value if the key doesn't already exists
-    // to be sure we never override a RATE_LIMITED
     final SetArgs args = new SetArgs().ex(AUTH_CACHE_DURATION).nx();
     ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
     .executeSupplier(() ->
-      redisClient.withCluster(cluster -> cluster.sync().set(aud, authHeader, args))
+      redisClient.withCluster(cluster -> cluster.sync().set(headerKey(aud), authHeader, args))
     );
   }
 

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -51,6 +51,7 @@ public class WebPushSender implements PushNotificationSender {
   private final FaultTolerantHttpClient httpClient;
   private final FaultTolerantRedisClusterClient redisClient;
   private final KeyPair vapidKp;
+  private final String vapidSub;
 
   private static final Timer SEND_NOTIFICATION_TIMER = Metrics.timer(name(WebPushSender.class, "sendNotification"));
   private static final String RETRY_NAME = ResilienceUtil.name(WebPushSender.class);
@@ -66,19 +67,21 @@ public class WebPushSender implements PushNotificationSender {
 
   private class RateLimitedException extends Exception {}
 
-  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp) throws IOException {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp, String vapidSub) throws IOException {
     this.httpClient = FaultTolerantHttpClient.newBuilder("webpush", executor)
       .withRedirect(HttpClient.Redirect.NEVER)
       .build();
     this.redisClient = redisClient;
     this.vapidKp = vapidKp;
+    this.vapidSub = vapidSub;
   }
 
   @VisibleForTesting
-  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp, FaultTolerantHttpClient httpClient) {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, KeyPair vapidKp, String vapidSub, FaultTolerantHttpClient httpClient) {
     this.httpClient = httpClient;
     this.redisClient = redisClient;
     this.vapidKp = vapidKp;
+    this.vapidSub = vapidSub;
   }
 
   @Override
@@ -97,7 +100,7 @@ public class WebPushSender implements PushNotificationSender {
 
     if (StringUtils.isBlank(authorization)) {
       try {
-        authorization = genAuthorization(vapidKp, aud, "mailto:TODO@localhost");
+        authorization = genAuthorization(vapidKp, aud, vapidSub);
       } catch (Exception e) {
         logger.warn("Error while making vapid authorization", e);
         return CompletableFuture.completedFuture(

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
 import org.whispersystems.textsecuregcm.util.ResilienceUtil;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
@@ -86,7 +87,15 @@ public class WebPushSender implements PushNotificationSender {
 
   @Override
   public CompletableFuture<SendPushNotificationResult> sendNotification(PushNotification pushNotification) {
-    final WebPushSubscription sub = (WebPushSubscription) pushNotification.pushToken().value();
+    final PushToken.WEBPUSH pushToken = (PushToken.WEBPUSH) pushNotification.pushToken();
+    final WebPushSubscription sub = pushToken.value();
+
+    if (!pushToken.activated()) {
+      return CompletableFuture.completedFuture(
+        new SendPushNotificationResult(false, Optional.of("Subscription not yet activated"), false, Optional.empty())
+      );
+    }
+
     final String aud = String.format("https://%s", sub.endpoint().getAuthority());
 
     String authorization;
@@ -117,6 +126,7 @@ public class WebPushSender implements PushNotificationSender {
       case ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY -> "attemptLoginContext";
       case CHALLENGE -> "challenge";
       case RATE_LIMIT_CHALLENGE -> "rateLimitChallenge";
+      case ACTIVATION_TOKEN -> "activationToken";
     };
 
     map.put(key, pushNotification.data() != null ? pushNotification.data() : "");

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSender.java
@@ -7,49 +7,84 @@ package org.whispersystems.textsecuregcm.push;
 
 import static org.whispersystems.textsecuregcm.metrics.MetricsUtil.name;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.net.HttpHeaders;
-import com.google.crypto.tink.apps.webpush.WebPushHybridEncrypt;
-
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
+import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
+import org.whispersystems.textsecuregcm.util.ResilienceUtil;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HttpHeaders;
+import com.google.crypto.tink.apps.webpush.WebPushHybridEncrypt;
+
+import io.lettuce.core.SetArgs;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 
 public class WebPushSender implements PushNotificationSender {
 
   private final FaultTolerantHttpClient httpClient;
 
   private static final Timer SEND_NOTIFICATION_TIMER = Metrics.timer(name(WebPushSender.class, "sendNotification"));
+  private static final String RETRY_NAME = ResilienceUtil.name(WebPushSender.class);
+  @VisibleForTesting
+  static final String RATE_LIMITED = "rate-limited";
+  /** Cache authorization header for 10 min */
+  private static final Duration AUTH_CACHE_DURATION = Duration.ofMinutes(10);
+  /**
+   * If the push server doesn't send a `Retry-After` header with 429,
+   * we wait for 5 min by default
+   */
+  private static final int DEFAULT_RETRY_AFTER = 300;
 
   private static final Logger logger = LoggerFactory.getLogger(WebPushSender.class);
+  private final FaultTolerantRedisClusterClient redisClient;
+
+  private class RateLimitedException extends Exception {}
 
   // TODO: Add keystore for the VAPID key
-  public WebPushSender (ExecutorService executor) throws IOException {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient) throws IOException {
     this.httpClient = FaultTolerantHttpClient.newBuilder("webpush", executor)
       .withRedirect(HttpClient.Redirect.NEVER)
       .build();
+    this.redisClient = redisClient;
   }
 
   @VisibleForTesting
-  public WebPushSender (ExecutorService executor, FaultTolerantHttpClient httpClient) {
+  public WebPushSender (ExecutorService executor, FaultTolerantRedisClusterClient redisClient, FaultTolerantHttpClient httpClient) {
     this.httpClient = httpClient;
+    this.redisClient = redisClient;
   }
 
   @Override
   public CompletableFuture<SendPushNotificationResult> sendNotification(PushNotification pushNotification) {
+    final WebPushSubscription sub = (WebPushSubscription) pushNotification.pushToken().value();
+    final String aud = String.format("https://%s", sub.endpoint().getAuthority());
+
+    String authorization;
+    try {
+      authorization = getCachedAuthorization(aud);
+    } catch (RateLimitedException e) {
+      return CompletableFuture.completedFuture(
+        new SendPushNotificationResult(false, Optional.of("Rate limited"), false, Optional.empty())
+      );
+    }
+
     final Map<String, String> map = new HashMap<String, String>();
 
     final String key = switch (pushNotification.notificationType()) {
@@ -62,7 +97,6 @@ public class WebPushSender implements PushNotificationSender {
     map.put(key, pushNotification.data() != null ? pushNotification.data() : "");
     map.put("urgency", pushNotification.urgent() ? "high" : "low");
 
-    final WebPushSubscription sub = (WebPushSubscription) pushNotification.pushToken().value();
     final byte[] body;
     try {
       final WebPushHybridEncrypt engine = new WebPushHybridEncrypt.Builder()
@@ -76,7 +110,6 @@ public class WebPushSender implements PushNotificationSender {
       logger.warn("Error while encrypting web push notification", e);
       return CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.of("Error while encrypting notification"), false, Optional.empty()));
     }
-
 
     final Timer.Sample sample = Timer.start();
 
@@ -112,11 +145,42 @@ public class WebPushSender implements PushNotificationSender {
                new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty());
            case 404, 403, 401, 410 ->
                new SendPushNotificationResult(false, Optional.of(String.valueOf(code)), true, Optional.of(Instant.now()));
-           // TODO: Handle Too many requests (429)
-           // case 429 -> ;
+           case 429 -> {
+             int retryAfterS;
+             try {
+               retryAfterS = response.headers().firstValue("Retry-After").map(v -> Integer.parseInt(v)).orElse(DEFAULT_RETRY_AFTER);
+             } catch (NumberFormatException e) {
+               retryAfterS = DEFAULT_RETRY_AFTER;
+             }
+             cacheRateLimit(aud, retryAfterS);
+             yield new SendPushNotificationResult(false, Optional.of("Rate limited"), false, Optional.empty());
+           }
            default ->
                new SendPushNotificationResult(false, Optional.of(String.valueOf(code)), false, Optional.empty());
         };
        });
+  }
+
+  /**
+   * @throws RateLimitedException if the aud server previously returned a 429 (Too Many Requests)
+   * @return the cached authorization header
+   */
+  private @Nullable String getCachedAuthorization(final String aud) throws RateLimitedException {
+    final String cached = ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
+    .executeSupplier(() ->
+      redisClient.withCluster(cluster -> cluster.sync().get(aud))
+    );
+    if (cached == RATE_LIMITED) {
+      throw new RateLimitedException();
+    }
+    return cached;
+  }
+
+  private void cacheRateLimit(final String aud, final int retryAfterS) {
+    final SetArgs args = new SetArgs().ex(retryAfterS);
+    ResilienceUtil.getGeneralRedisRetry(RETRY_NAME)
+    .executeSupplier(() ->
+      redisClient.withCluster(cluster -> cluster.sync().set(aud, RATE_LIMITED, args))
+    );
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSubscription.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSubscription.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2022 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.push;
+
+import org.whispersystems.textsecuregcm.util.ByteArrayBase64UrlAdapter;
+import org.whispersystems.textsecuregcm.util.ExactlySize;
+import org.whispersystems.textsecuregcm.util.P256ECPublicKeyAdapter;
+import org.whispersystems.textsecuregcm.util.ValidHttpsURI;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.net.URI;
+import java.security.interfaces.ECPublicKey;
+
+public record WebPushSubscription(
+                                @NotNull
+                                @ValidHttpsURI
+                                @JsonProperty(required = true)
+                                URI endpoint,
+                                @NotNull
+                                @JsonProperty(value = "publicKey", required = true)
+                                @JsonSerialize(using = P256ECPublicKeyAdapter.Serializer.class)
+                                @JsonDeserialize(using = P256ECPublicKeyAdapter.Deserializer.class)
+                                ECPublicKey userPublicKey,
+                                @NotNull
+                                @ExactlySize(16)
+                                @JsonProperty(value = "auth", required = true)
+                                @JsonSerialize(using = ByteArrayBase64UrlAdapter.Serializing.class)
+                                @JsonDeserialize(using = ByteArrayBase64UrlAdapter.Deserializing.class)
+                                byte[] userAuth) {}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSubscription.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/push/WebPushSubscription.java
@@ -18,6 +18,7 @@ import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
 import java.security.interfaces.ECPublicKey;
+import java.util.Arrays;
 
 public record WebPushSubscription(
                                 @NotNull
@@ -34,4 +35,20 @@ public record WebPushSubscription(
                                 @JsonProperty(value = "auth", required = true)
                                 @JsonSerialize(using = ByteArrayBase64UrlAdapter.Serializing.class)
                                 @JsonDeserialize(using = ByteArrayBase64UrlAdapter.Deserializing.class)
-                                byte[] userAuth) {}
+                                byte[] userAuth) {
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+        return true;
+    }
+    if (other == null) {
+        return false;
+    }
+    if (!(other instanceof WebPushSubscription)) {
+        return false;
+    }
+    return endpoint.equals(((WebPushSubscription) other).endpoint) &&
+      userPublicKey.equals(((WebPushSubscription) other).userPublicKey) &&
+      Arrays.equals(userAuth, ((WebPushSubscription) other).userAuth);
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.validation.Valid;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -20,6 +21,7 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
 import org.whispersystems.textsecuregcm.auth.SaltedTokenHash;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.util.ByteArrayAdapter;
 import org.whispersystems.textsecuregcm.util.DeviceCapabilityAdapter;
 import org.whispersystems.textsecuregcm.util.DeviceNameByteArrayAdapter;
@@ -60,6 +62,10 @@ public class Device {
 
   @JsonProperty
   private String  apnId;
+
+  @Valid
+  @JsonProperty
+  private WebPushSubscription webPush;
 
   @JsonProperty
   private long pushTimestamp;
@@ -131,6 +137,18 @@ public class Device {
     this.gcmId = gcmId;
 
     if (gcmId != null) {
+      this.pushTimestamp = System.currentTimeMillis();
+    }
+  }
+
+  public WebPushSubscription getWebPush() {
+    return webPush;
+  }
+
+  public void setWebPush(WebPushSubscription webPush) {
+    this.webPush = webPush;
+
+    if (webPush != null) {
       this.pushTimestamp = System.currentTimeMillis();
     }
   }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
@@ -19,8 +19,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.commons.lang3.StringUtils;
 import org.whispersystems.textsecuregcm.auth.SaltedTokenHash;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.NotPushRegisteredException;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
+import org.whispersystems.textsecuregcm.push.PushNotification.TokenType;
 import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.util.ByteArrayAdapter;
 import org.whispersystems.textsecuregcm.util.DeviceCapabilityAdapter;
@@ -264,5 +269,28 @@ public class Device {
 
   public String getUserAgent() {
     return this.userAgent;
+  }
+
+  public static PushToken<?> getPushToken(final Device device) throws NotPushRegisteredException {
+    final String gcmId = device.getGcmId();
+    final String apnId = device.getApnId();
+    final WebPushSubscription webPushSub = device.getWebPush();
+    if (StringUtils.isNotBlank(gcmId)) {
+      return new PushToken.FCM(gcmId);
+    } else if (StringUtils.isNotBlank(apnId)) {
+      return new PushToken.APN(apnId);
+    } else if (webPushSub != null) {
+      return new PushToken.WEBPUSH(webPushSub);
+    } else {
+      throw new NotPushRegisteredException();
+    }
+  }
+
+  public static @Nullable PushToken<?> getPushToken(final Device device, final TokenType tokenType) {
+    return switch (tokenType) {
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(device.getWebPush());
+      case TokenType.FCM -> new PushToken.FCM(device.getGcmId());
+      case TokenType.APN -> new PushToken.APN(device.getApnId());
+    };
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/storage/Device.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.whispersystems.textsecuregcm.auth.SaltedTokenHash;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
 import org.whispersystems.textsecuregcm.push.NotPushRegisteredException;
+import org.whispersystems.textsecuregcm.push.WebPushActivation;
 import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.push.PushNotification.TokenType;
 import org.whispersystems.textsecuregcm.push.WebPushSubscription;
@@ -71,6 +72,9 @@ public class Device {
   @Valid
   @JsonProperty
   private WebPushSubscription webPush;
+
+  @JsonProperty
+  private WebPushActivation webPushActivation;
 
   @JsonProperty
   private long pushTimestamp;
@@ -156,6 +160,18 @@ public class Device {
     if (webPush != null) {
       this.pushTimestamp = System.currentTimeMillis();
     }
+  }
+
+  public boolean getWebPushActivated() {
+    return webPushActivation != null && webPushActivation.activated();
+  }
+
+  public WebPushActivation getWebPushActivation() {
+    return webPushActivation;
+  }
+
+  public void setWebPushActivation(WebPushActivation webPushActivation) {
+    this.webPushActivation = webPushActivation;
   }
 
   public byte getId() {
@@ -280,7 +296,7 @@ public class Device {
     } else if (StringUtils.isNotBlank(apnId)) {
       return new PushToken.APN(apnId);
     } else if (webPushSub != null) {
-      return new PushToken.WEBPUSH(webPushSub);
+      return new PushToken.WEBPUSH(webPushSub, device.getWebPushActivated());
     } else {
       throw new NotPushRegisteredException();
     }
@@ -288,7 +304,7 @@ public class Device {
 
   public static @Nullable PushToken<?> getPushToken(final Device device, final TokenType tokenType) {
     return switch (tokenType) {
-      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(device.getWebPush());
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(device.getWebPush(), device.getWebPushActivated());
       case TokenType.FCM -> new PushToken.FCM(device.getGcmId());
       case TokenType.APN -> new PushToken.APN(device.getApnId());
     };

--- a/service/src/main/java/org/whispersystems/textsecuregcm/util/P256ECPublicKeyAdapter.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/util/P256ECPublicKeyAdapter.java
@@ -79,7 +79,7 @@ public class P256ECPublicKeyAdapter {
       }
     }
 
-    private ECPublicKey deserializePublicKey(final byte[] publicKeyBytes) throws GeneralSecurityException {
+    private static ECPublicKey deserializePublicKey(final byte[] publicKeyBytes) throws GeneralSecurityException {
       ECPoint point = EllipticCurves.pointDecode(
         EllipticCurves.CurveType.NIST_P256,
         EllipticCurves.PointFormatType.UNCOMPRESSED,
@@ -88,6 +88,11 @@ public class P256ECPublicKeyAdapter {
       ECParameterSpec spec = EllipticCurves.getCurveSpec(EllipticCurves.CurveType.NIST_P256);
       KeyFactory factory = KeyFactory.getInstance("EC");
       return (ECPublicKey) factory.generatePublic(new ECPublicKeySpec(point, spec));
+    }
+
+    public static ECPublicKey deserializePublicKey(final String b64PublicKey) throws GeneralSecurityException {
+      byte[] publicKeyBytes = Base64.getUrlDecoder().decode(b64PublicKey);
+      return deserializePublicKey(publicKeyBytes);
     }
   }
 }

--- a/service/src/main/java/org/whispersystems/textsecuregcm/util/P256ECPublicKeyAdapter.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/util/P256ECPublicKeyAdapter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.util;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.util.Base64;
+
+import org.whispersystems.textsecuregcm.metrics.MetricsUtil;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.google.crypto.tink.subtle.EllipticCurves;
+
+import io.micrometer.core.instrument.Metrics;
+
+public class P256ECPublicKeyAdapter {
+
+  private static final String REASON_TAG_NAME = "reason";
+
+  public static class Serializer extends JsonSerializer<ECPublicKey> {
+    private final String invalidKeyCounterName = MetricsUtil.name(getClass(), "invalidKey");
+
+    @Override
+    public void serialize(final ECPublicKey publicKey,
+        final JsonGenerator jsonGenerator,
+        final SerializerProvider serializerProvider) throws IOException {
+      try {
+      jsonGenerator.writeString(Base64.getUrlEncoder().encodeToString(serializePublicKey(publicKey)));
+      } catch (final GeneralSecurityException e) {
+        Metrics.counter(invalidKeyCounterName, REASON_TAG_NAME, "invalid-key").increment();
+        throw new JsonGenerationException("Could not serialize public key", e, jsonGenerator);
+      }
+
+    }
+
+    private byte[] serializePublicKey(final ECPublicKey publicKey) throws GeneralSecurityException {
+      return EllipticCurves.pointEncode(
+        EllipticCurves.CurveType.NIST_P256,
+        EllipticCurves.PointFormatType.UNCOMPRESSED,
+        publicKey.getW()
+      );
+    }
+  }
+
+  public static class Deserializer extends JsonDeserializer<ECPublicKey> {
+    private final String invalidKeyCounterName = MetricsUtil.name(getClass(), "invalidKey");
+
+    @Override
+    public ECPublicKey deserialize(final JsonParser parser, final DeserializationContext context) throws IOException {
+      final byte[] publicKeyBytes;
+
+      try {
+        publicKeyBytes = Base64.getUrlDecoder().decode(parser.getValueAsString());
+      } catch (final IllegalArgumentException e) {
+        Metrics.counter(invalidKeyCounterName, REASON_TAG_NAME, "illegal-base64").increment();
+        throw new JsonParseException(parser, "Could not parse public key as a base64-encoded value", e);
+      }
+
+      try {
+        return deserializePublicKey(publicKeyBytes);
+      } catch (final GeneralSecurityException e) {
+        Metrics.counter(invalidKeyCounterName, REASON_TAG_NAME, "invalid-key").increment();
+        throw new JsonParseException(parser, "Could not interpret key bytes as a public key", e);
+      }
+    }
+
+    private ECPublicKey deserializePublicKey(final byte[] publicKeyBytes) throws GeneralSecurityException {
+      ECPoint point = EllipticCurves.pointDecode(
+        EllipticCurves.CurveType.NIST_P256,
+        EllipticCurves.PointFormatType.UNCOMPRESSED,
+        publicKeyBytes
+      );
+      ECParameterSpec spec = EllipticCurves.getCurveSpec(EllipticCurves.CurveType.NIST_P256);
+      KeyFactory factory = KeyFactory.getInstance("EC");
+      return (ECPublicKey) factory.generatePublic(new ECPublicKeySpec(point, spec));
+    }
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/util/ValidHttpsURI.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/util/ValidHttpsURI.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.util;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.net.URI;
+import java.util.Objects;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+
+/**
+ * Constraint annotation that requires annotated entity is a valid HTTPS URI.
+ */
+@Target({ FIELD, METHOD, CONSTRUCTOR, PARAMETER, ANNOTATION_TYPE, TYPE_USE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = {
+  ValidHttpsURI.Validator.class,
+})
+@Documented
+public @interface ValidHttpsURI {
+
+  String message() default "value is not a valid https URI";
+
+  Class<?>[] groups() default { };
+
+  Class<? extends Payload>[] payload() default { };
+
+  class Validator implements ConstraintValidator<ValidHttpsURI, URI> {
+
+    @Override
+    public boolean isValid(final URI value, final ConstraintValidatorContext context) {
+      if (Objects.isNull(value)) {
+        return false;
+      }
+      context.disableDefaultConstraintViolation();
+      String scheme = value.getScheme();
+      if (scheme == null || !scheme.equals("https")) {
+        String msg = String.format("URI scheme must be https (was: %s)", scheme);
+        context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
+        return false;
+      } else if (value.getHost() == null){
+        String msg = "URI host must not be null";
+        context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
+        return false;
+      } else {
+        return true;
+      }
+    }
+  }
+}

--- a/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
@@ -51,6 +51,7 @@ import org.whispersystems.textsecuregcm.push.FcmSender;
 import org.whispersystems.textsecuregcm.push.PushNotificationManager;
 import org.whispersystems.textsecuregcm.push.PushNotificationScheduler;
 import org.whispersystems.textsecuregcm.push.RedisMessageAvailabilityManager;
+import org.whispersystems.textsecuregcm.push.WebPushSender;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClient;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
 import org.whispersystems.textsecuregcm.securestorage.SecureStorageClient;
@@ -105,6 +106,7 @@ record CommandDependencies(
     RegistrationRecoveryPasswordsManager registrationRecoveryPasswordsManager,
     APNSender apnSender,
     FcmSender fcmSender,
+    WebPushSender webPushSender,
     PushNotificationManager pushNotificationManager,
     PushNotificationExperimentSamples pushNotificationExperimentSamples,
     FaultTolerantRedisClusterClient cacheCluster,
@@ -167,6 +169,8 @@ record CommandDependencies(
     ExecutorService apnSenderExecutor = environment.lifecycle().executorService(name(WhisperServerService.class, "apnSender-%d"))
         .maxThreads(1).minThreads(1).build();
     ExecutorService fcmSenderExecutor = environment.lifecycle().executorService(name(WhisperServerService.class, "fcmSender-%d"))
+        .maxThreads(16).minThreads(16).build();
+    ExecutorService webPushSenderExecutor = environment.lifecycle().executorService(name(WhisperServerService.class, "webPushSender-%d"))
         .maxThreads(16).minThreads(16).build();
     ExecutorService clientEventExecutor = environment.lifecycle()
         .virtualExecutorService(name(WhisperServerService.class, "clientEvent-%d"));
@@ -350,10 +354,11 @@ record CommandDependencies(
 
     APNSender apnSender = new APNSender(apnSenderExecutor, configuration.getApnConfiguration());
     FcmSender fcmSender = new FcmSender(fcmSenderExecutor, configuration.getFcmConfiguration().credentials().value());
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor);
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,
-        apnSender, fcmSender, accountsManager, 0, 0, retryExecutor);
+        apnSender, fcmSender, webPushSender, accountsManager, 0, 0, retryExecutor);
     PushNotificationManager pushNotificationManager = new PushNotificationManager(accountsManager,
-        apnSender, fcmSender, pushNotificationScheduler);
+        apnSender, fcmSender, webPushSender, pushNotificationScheduler);
     PushNotificationExperimentSamples pushNotificationExperimentSamples =
         new PushNotificationExperimentSamples(dynamoDbAsyncClient,
             configuration.getDynamoDbTables().getPushNotificationExperimentSamples().getTableName(),
@@ -377,6 +382,7 @@ record CommandDependencies(
         registrationRecoveryPasswordsManager,
         apnSender,
         fcmSender,
+        webPushSender,
         pushNotificationManager,
         pushNotificationExperimentSamples,
         cacheCluster,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
@@ -356,7 +356,7 @@ record CommandDependencies(
 
     APNSender apnSender = new APNSender(apnSenderExecutor, configuration.getApnConfiguration());
     FcmSender fcmSender = new FcmSender(fcmSenderExecutor, configuration.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster);
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster, configuration.getWebPushConfiguration().vapidStaticKeyPair());
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,
         apnSender, fcmSender, webPushSender, accountsManager, 0, 0, retryExecutor);
     PushNotificationManager pushNotificationManager = new PushNotificationManager(accountsManager,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
@@ -356,7 +356,12 @@ record CommandDependencies(
 
     APNSender apnSender = new APNSender(apnSenderExecutor, configuration.getApnConfiguration());
     FcmSender fcmSender = new FcmSender(fcmSenderExecutor, configuration.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster, configuration.getWebPushConfiguration().vapidStaticKeyPair());
+    WebPushSender webPushSender = new WebPushSender(
+      webPushSenderExecutor,
+      webPushSenderCluster,
+      configuration.getWebPushConfiguration().vapidStaticKeyPair(),
+      configuration.getWebPushConfiguration().vapidSub()
+    );
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,
         apnSender, fcmSender, webPushSender, accountsManager, 0, 0, retryExecutor);
     PushNotificationManager pushNotificationManager = new PushNotificationManager(accountsManager,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/workers/CommandDependencies.java
@@ -147,6 +147,8 @@ record CommandDependencies(
 
     FaultTolerantRedisClusterClient cacheCluster = configuration.getCacheClusterConfiguration()
         .build("main_cache", redisClientResourcesBuilder);
+    FaultTolerantRedisClusterClient webPushSenderCluster = configuration.getPushSchedulerCluster()
+        .build("webpush", redisClientResourcesBuilder);
     FaultTolerantRedisClusterClient pushSchedulerCluster = configuration.getPushSchedulerCluster()
         .build("push_scheduler", redisClientResourcesBuilder);
     FaultTolerantRedisClient pubsubClient =
@@ -354,7 +356,7 @@ record CommandDependencies(
 
     APNSender apnSender = new APNSender(apnSenderExecutor, configuration.getApnConfiguration());
     FcmSender fcmSender = new FcmSender(fcmSenderExecutor, configuration.getFcmConfiguration().credentials().value());
-    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor);
+    WebPushSender webPushSender = new WebPushSender(webPushSenderExecutor, webPushSenderCluster);
     PushNotificationScheduler pushNotificationScheduler = new PushNotificationScheduler(pushSchedulerCluster,
         apnSender, fcmSender, webPushSender, accountsManager, 0, 0, retryExecutor);
     PushNotificationManager pushNotificationManager = new PushNotificationManager(accountsManager,

--- a/service/src/main/java/org/whispersystems/textsecuregcm/workers/ScheduledApnPushNotificationSenderServiceCommand.java
+++ b/service/src/main/java/org/whispersystems/textsecuregcm/workers/ScheduledApnPushNotificationSenderServiceCommand.java
@@ -88,6 +88,7 @@ public class ScheduledApnPushNotificationSenderServiceCommand extends ServerComm
         deps.pushSchedulerCluster(),
         deps.apnSender(),
         deps.fcmSender(),
+        deps.webPushSender(),
         deps.accountsManager(),
         namespace.getInt(WORKER_COUNT),
         namespace.getInt(MAX_CONCURRENCY),

--- a/service/src/main/proto/org/signal/chat/device.proto
+++ b/service/src/main/proto/org/signal/chat/device.proto
@@ -144,6 +144,23 @@ message SetPushTokenRequest {
     string fcm_token = 1;
   }
 
+  message WebPushRequest {
+    /**
+     * The URL to send push notifications to, defined as a *push resource* in RFC8030
+     */
+    string endpoint = 1;
+
+    /**
+     * Device's P-256 public key, URL-safe base64 encoded, to encrypt push notification. Defined in RFC8291
+     */
+    string publicKey = 2;
+
+    /**
+     * Device's authentication pre-shared secret, URL-safe base64 encoded, to encrypt push notification. Defined in RFC8291
+     */
+    string auth = 3;
+  }
+
   oneof token_request {
     /**
      * If present, specifies the APNs device token(s) the server will use to
@@ -156,6 +173,12 @@ message SetPushTokenRequest {
      * message notifications to the authenticated device.
      */
     FcmTokenRequest fcm_token_request = 2;
+
+    /**
+     * If present, specifies the Web Push subscription the server will use to send new
+     * message notifications to the authenticated device.
+     */
+    WebPushRequest web_push_request = 3;
   }
 }
 

--- a/service/src/main/proto/org/signal/chat/device.proto
+++ b/service/src/main/proto/org/signal/chat/device.proto
@@ -47,6 +47,12 @@ service Devices {
   rpc SetPushToken(SetPushTokenRequest) returns (SetPushTokenResponse) {}
 
   /**
+   * Activate push token to allow the server to send push notification with the current
+   * subscription. Required and used only for Web Push subscriptions
+   */
+  rpc ActivatePushToken(ActivatePushTokenRequest) returns (ActivatePushTokenResponse) {}
+
+  /**
    * Removes any push tokens associated with the authenticated device. After
    * calling this method, the server will assume that the authenticated device
    * will periodically poll for new messages.
@@ -183,6 +189,15 @@ message SetPushTokenRequest {
 }
 
 message SetPushTokenResponse {}
+
+message ActivatePushTokenRequest {
+  /**
+   * Token sent via a push notification to validate the subscription
+   */
+  string activationToken = 1;
+}
+
+message ActivatePushTokenResponse {}
 
 message ClearPushTokenRequest {}
 

--- a/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AccountControllerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AccountControllerTest.java
@@ -309,6 +309,41 @@ class AccountControllerTest {
     }
   }
 
+
+  @Test
+  void testSetWebPush() {
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("""
+        {
+            "endpoint": "https://domain.tld/random1",
+            "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+            "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+        """))) {
+      assertThat(response.getStatus()).isEqualTo(204);
+
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPush(any());
+      verify(accountsManager, times(1)).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
+    }
+  }
+
+  @Test
+  void testSetWebPushInvalidrequest() {
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("{}"))) {
+
+      assertThat(response.getStatus()).isEqualTo(422);
+    }
+  }
+
   @Test
   void testSetApnId() {
     try (final Response response = resources.getJerseyTest()

--- a/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AccountControllerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/controllers/AccountControllerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.net.HttpHeaders;
 import io.dropwizard.auth.AuthValueFactoryProvider;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
@@ -82,6 +83,9 @@ import org.whispersystems.textsecuregcm.mappers.ImpossiblePhoneNumberExceptionMa
 import org.whispersystems.textsecuregcm.mappers.JsonMappingExceptionMapper;
 import org.whispersystems.textsecuregcm.mappers.NonNormalizedPhoneNumberExceptionMapper;
 import org.whispersystems.textsecuregcm.mappers.RateLimitExceededExceptionMapper;
+import org.whispersystems.textsecuregcm.push.PushNotificationManager;
+import org.whispersystems.textsecuregcm.push.WebPushActivation;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountBadge;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
@@ -136,6 +140,7 @@ class AccountControllerTest {
   private static final RegistrationRecoveryPasswordsManager registrationRecoveryPasswordsManager =
       mock(RegistrationRecoveryPasswordsManager.class);
   private static final UsernameHashZkProofVerifier usernameZkProofVerifier = mock(UsernameHashZkProofVerifier.class);
+  private static final PushNotificationManager pushNotificationManager = mock(PushNotificationManager.class);
 
   private final byte[] registration_lock_key = new byte[32];
 
@@ -158,7 +163,8 @@ class AccountControllerTest {
               accountsManager,
           rateLimiters,
           registrationRecoveryPasswordsManager,
-          usernameZkProofVerifier
+          usernameZkProofVerifier,
+          pushNotificationManager
       ))
       .build();
 
@@ -309,7 +315,6 @@ class AccountControllerTest {
     }
   }
 
-
   @Test
   void testSetWebPush() {
     try (final Response response = resources.getJerseyTest()
@@ -327,7 +332,131 @@ class AccountControllerTest {
       assertThat(response.getStatus()).isEqualTo(204);
 
       verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPush(any());
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPushActivation(any());
       verify(accountsManager, times(1)).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
+    }
+  }
+
+  @Test
+  void testSetWebPushSameSubInactive() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPush()).thenReturn(webPushSub);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPushActivated()).thenReturn(false);
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("""
+        {
+            "endpoint": "https://domain.tld/random1",
+            "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+            "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+        """))) {
+      assertThat(response.getStatus()).isEqualTo(204);
+
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPush(any());
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPushActivation(any());
+      verify(accountsManager, times(1)).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
+    }
+  }
+
+  @Test
+  void testSetWebPushAlreadyActivated() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPush()).thenReturn(webPushSub);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPushActivated()).thenReturn(true);
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("""
+        {
+            "endpoint": "https://domain.tld/random1",
+            "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+            "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+        """))) {
+      assertThat(response.getStatus()).isEqualTo(204);
+
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, never()).setWebPush(any());
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, never()).setWebPushActivation(any());
+      verify(accountsManager, never()).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
+    }
+  }
+
+  @Test
+  void testActivateWebPushSameToken() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final WebPushActivation deviceActivation = new WebPushActivation(false, "f94694be-f105-44f7-acca-8c025bde71a7");
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPush()).thenReturn(webPushSub);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPushActivation()).thenReturn(deviceActivation);
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/activate/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("""
+        {
+            "activationToken": "f94694be-f105-44f7-acca-8c025bde71a7"
+        }
+        """))) {
+      assertThat(response.getStatus()).isEqualTo(204);
+
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, never()).setWebPush(any());
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, times(1)).setWebPushActivation(any());
+      verify(accountsManager, times(1)).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
+    }
+  }
+
+
+  @Test
+  void testActivateWebPushInvalidToken() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final WebPushActivation deviceActivation = new WebPushActivation(false, "f94694be-f105-44f7-acca-8c025bde71a7");
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPush()).thenReturn(webPushSub);
+    when(AuthHelper.VALID_DEVICE_3_PRIMARY.getWebPushActivation()).thenReturn(deviceActivation);
+    try (final Response response = resources.getJerseyTest()
+        .target("/v1/accounts/webpush/activate/")
+        .request()
+        .header(HttpHeaders.AUTHORIZATION,
+            AuthHelper.getAuthHeader(AuthHelper.VALID_UUID_3, AuthHelper.VALID_PASSWORD_3_PRIMARY))
+        .put(Entity.json("""
+        {
+            "activationToken": "b6cf9c40-012a-4c92-ab7b-e1dc118f72f0"
+        }
+        """))) {
+      assertThat(response.getStatus()).isEqualTo(204);
+
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, never()).setWebPush(any());
+      verify(AuthHelper.VALID_DEVICE_3_PRIMARY, never()).setWebPushActivation(any());
+      verify(accountsManager, never()).updateDevice(eq(AuthHelper.VALID_ACCOUNT_3), anyByte(), any());
     }
   }
 

--- a/service/src/test/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcServiceTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.whispersystems.textsecuregcm.grpc.GrpcTestUtils.assertStatusException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import java.nio.charset.StandardCharsets;
@@ -49,10 +50,12 @@ import org.signal.chat.device.SetDeviceNameResponse;
 import org.signal.chat.device.SetPushTokenRequest;
 import org.signal.chat.device.SetPushTokenResponse;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
 import org.whispersystems.textsecuregcm.storage.DeviceCapability;
+import org.whispersystems.textsecuregcm.util.SystemMapper;
 import org.whispersystems.textsecuregcm.util.TestRandomUtil;
 
 class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, DevicesGrpc.DevicesBlockingStub> {
@@ -300,7 +303,8 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
   void setPushToken(final byte deviceId,
       final SetPushTokenRequest request,
       @Nullable final String expectedApnsToken,
-      @Nullable final String expectedFcmToken) {
+      @Nullable final String expectedFcmToken,
+      @Nullable final WebPushSubscription expectedWebPush) {
 
     mockAuthenticationInterceptor().setAuthenticatedDevice(AUTHENTICATED_ACI, deviceId);
 
@@ -311,12 +315,23 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
 
     verify(device).setApnId(expectedApnsToken);
     verify(device).setGcmId(expectedFcmToken);
+    verify(device).setWebPush(expectedWebPush);
     verify(device).setFetchesMessages(false);
   }
 
-  private static Stream<Arguments> setPushToken() {
+  private static Stream<Arguments> setPushToken() throws JsonProcessingException {
     final String apnsToken = "apns-token";
     final String fcmToken = "fcm-token";
+    final String endpoint = "https://domain.tld/random1";
+    final String userAuth = "BTBZMqHH6r4Tts7J_aSIgg";
+    final String userPublicKey = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    final WebPushSubscription webPush = SystemMapper.jsonMapper().readValue(String.format("""
+        {
+          "endpoint": "%s",
+          "auth": "%s",
+          "publicKey": "%s"
+        }
+      """, endpoint, userAuth, userPublicKey), WebPushSubscription.class);
 
     final Stream.Builder<Arguments> streamBuilder = Stream.builder();
 
@@ -327,7 +342,7 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
                   .setApnsToken(apnsToken)
                   .build())
               .build(),
-          apnsToken, null));
+          apnsToken, null, null));
 
       streamBuilder.add(Arguments.of(deviceId,
           SetPushTokenRequest.newBuilder()
@@ -335,7 +350,17 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
                   .setFcmToken(fcmToken)
                   .build())
               .build(),
-          null, fcmToken));
+          null, fcmToken, null));
+
+      streamBuilder.add(Arguments.of(deviceId,
+          SetPushTokenRequest.newBuilder()
+              .setWebPushRequest(SetPushTokenRequest.WebPushRequest.newBuilder()
+                  .setEndpoint(endpoint)
+                  .setPublicKey(userPublicKey)
+                  .setAuth(userAuth)
+                  .build())
+              .build(),
+          null, null, webPush));
     }
 
     return streamBuilder.build();
@@ -345,11 +370,13 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
   @MethodSource
   void setPushTokenUnchanged(final SetPushTokenRequest request,
       @Nullable final String apnsToken,
-      @Nullable final String fcmToken) {
+      @Nullable final String fcmToken,
+      @Nullable final WebPushSubscription webPush) {
 
     final Device device = mock(Device.class);
     when(device.getApnId()).thenReturn(apnsToken);
     when(device.getGcmId()).thenReturn(fcmToken);
+    when(device.getWebPush()).thenReturn(webPush);
 
     when(authenticatedAccount.getDevice(AUTHENTICATED_DEVICE_ID)).thenReturn(Optional.of(device));
 
@@ -358,9 +385,19 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
     verify(accountsManager, never()).updateDevice(any(), anyByte(), any());
   }
 
-  private static Stream<Arguments> setPushTokenUnchanged() {
+  private static Stream<Arguments> setPushTokenUnchanged() throws JsonProcessingException {
     final String apnsToken = "apns-token";
     final String fcmToken = "fcm-token";
+    final String endpoint = "https://domain.tld/random1";
+    final String userAuth = "BTBZMqHH6r4Tts7J_aSIgg";
+    final String userPublicKey = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
+    final WebPushSubscription webPush = SystemMapper.jsonMapper().readValue(String.format("""
+        {
+          "endpoint": "%s",
+          "auth": "%s",
+          "publicKey": "%s"
+        }
+      """, endpoint, userAuth, userPublicKey), WebPushSubscription.class);
 
     return Stream.of(
         Arguments.of(SetPushTokenRequest.newBuilder()
@@ -368,14 +405,23 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
                     .setApnsToken(apnsToken)
                     .build())
                 .build(),
-            apnsToken, null, false),
+            apnsToken, null, null, false),
 
         Arguments.of(SetPushTokenRequest.newBuilder()
                 .setFcmTokenRequest(SetPushTokenRequest.FcmTokenRequest.newBuilder()
                     .setFcmToken(fcmToken)
                     .build())
                 .build(),
-            null, fcmToken, false)
+            null, fcmToken, null, false),
+
+        Arguments.of(SetPushTokenRequest.newBuilder()
+                .setWebPushRequest(SetPushTokenRequest.WebPushRequest.newBuilder()
+                    .setEndpoint(endpoint)
+                    .setPublicKey(userPublicKey)
+                    .setAuth(userAuth)
+                    .build())
+                .build(),
+            null, null, webPush, false)
     );
   }
 
@@ -389,6 +435,9 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
   }
 
   private static Stream<Arguments> setPushTokenIllegalArgument() {
+    final String invalidEndpoint = "http://domain.tld/random1";
+    final String userAuth = "BTBZMqHH6r4Tts7J_aSIgg";
+    final String userPublicKey = "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4";
     return Stream.of(
         Arguments.of(SetPushTokenRequest.newBuilder().build()),
 
@@ -398,6 +447,23 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
 
         Arguments.of(SetPushTokenRequest.newBuilder()
             .setFcmTokenRequest(SetPushTokenRequest.FcmTokenRequest.newBuilder().build())
+            .build()),
+
+        // With a missing field
+        Arguments.of(SetPushTokenRequest.newBuilder()
+            .setWebPushRequest(SetPushTokenRequest.WebPushRequest.newBuilder()
+              .setPublicKey(userPublicKey)
+              .setAuth(userAuth)
+              .build())
+            .build()),
+
+        // With an invalid field
+        Arguments.of(SetPushTokenRequest.newBuilder()
+            .setWebPushRequest(SetPushTokenRequest.WebPushRequest.newBuilder()
+              .setEndpoint(invalidEndpoint)
+              .setPublicKey(userPublicKey)
+              .setAuth(userAuth)
+              .build())
             .build())
     );
   }
@@ -407,6 +473,7 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
   void clearPushToken(final byte deviceId,
       @Nullable final String apnsToken,
       @Nullable final String fcmToken,
+      @Nullable final WebPushSubscription webPush,
       @Nullable final String expectedUserAgent) {
 
     mockAuthenticationInterceptor().setAuthenticatedDevice(AUTHENTICATED_ACI, deviceId);
@@ -416,12 +483,14 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
     when(device.isPrimary()).thenReturn(deviceId == Device.PRIMARY_ID);
     when(device.getApnId()).thenReturn(apnsToken);
     when(device.getGcmId()).thenReturn(fcmToken);
+    when(device.getWebPush()).thenReturn(webPush);
     when(authenticatedAccount.getDevice(deviceId)).thenReturn(Optional.of(device));
 
     final ClearPushTokenResponse ignored = authenticatedServiceStub().clearPushToken(ClearPushTokenRequest.newBuilder().build());
 
     verify(device).setApnId(null);
     verify(device).setGcmId(null);
+    verify(device).setWebPush(null);
     verify(device).setFetchesMessages(true);
 
     if (expectedUserAgent != null) {
@@ -431,14 +500,23 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
     }
   }
 
-  private static Stream<Arguments> clearPushToken() {
+  private static Stream<Arguments> clearPushToken() throws JsonProcessingException {
+    final WebPushSubscription webPush = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
     return Stream.of(
-        Arguments.of(Device.PRIMARY_ID, "apns-token", null, "OWI"),
-        Arguments.of(Device.PRIMARY_ID, null, "fcm-token", "OWA"),
-        Arguments.of(Device.PRIMARY_ID, null, null, null),
-        Arguments.of((byte) (Device.PRIMARY_ID + 1), "apns-token", null, "OWP"),
-        Arguments.of((byte) (Device.PRIMARY_ID + 1), null, "fcm-token", "OWA"),
-        Arguments.of((byte) (Device.PRIMARY_ID + 1), null, null, null)
+        Arguments.of(Device.PRIMARY_ID, "apns-token", null, null, "OWI"),
+        Arguments.of(Device.PRIMARY_ID, null, "fcm-token", null, "OWA"),
+        Arguments.of(Device.PRIMARY_ID, null, null, webPush, null),
+        Arguments.of(Device.PRIMARY_ID, null, null, null, null),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), "apns-token", null, null, "OWP"),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), null, "fcm-token", null, "OWA"),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), null, null, webPush, null),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), null, null, null, null)
     );
   }
 

--- a/service/src/test/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcServiceTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/grpc/DevicesGrpcServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyByte;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.whispersystems.textsecuregcm.grpc.GrpcTestUtils.assertStatusException;
 
@@ -35,7 +36,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.signal.chat.device.ActivatePushTokenRequest;
+import org.signal.chat.device.ActivatePushTokenResponse;
 import org.signal.chat.device.ClearPushTokenRequest;
 import org.signal.chat.device.ClearPushTokenResponse;
 import org.signal.chat.device.DevicesGrpc;
@@ -50,6 +54,7 @@ import org.signal.chat.device.SetDeviceNameResponse;
 import org.signal.chat.device.SetPushTokenRequest;
 import org.signal.chat.device.SetPushTokenResponse;
 import org.whispersystems.textsecuregcm.identity.IdentityType;
+import org.whispersystems.textsecuregcm.push.WebPushActivation;
 import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
@@ -465,6 +470,62 @@ class DevicesGrpcServiceTest extends SimpleBaseGrpcTest<DevicesGrpcService, Devi
               .setAuth(userAuth)
               .build())
             .build())
+    );
+  }
+
+
+  @ParameterizedTest
+  @MethodSource
+  void activatePushToken(final byte deviceId,
+    @Nullable final WebPushActivation deviceActivation,
+    @Nullable final String tokenSent,
+    @Nullable final boolean expectedSet) {
+
+    mockAuthenticationInterceptor().setAuthenticatedDevice(AUTHENTICATED_ACI, deviceId);
+
+    final Device device = mock(Device.class);
+    final WebPushSubscription webPush = mock(WebPushSubscription.class);
+    when(device.getId()).thenReturn(deviceId);
+    when(device.isPrimary()).thenReturn(deviceId == Device.PRIMARY_ID);
+    when(device.getWebPush()).thenReturn(webPush);
+    when(device.getWebPushActivation()).thenReturn(deviceActivation);
+    when(authenticatedAccount.getDevice(deviceId)).thenReturn(Optional.of(device));
+
+    if (tokenSent != null) {
+      final ActivatePushTokenResponse ignored = authenticatedServiceStub().activatePushToken(
+        ActivatePushTokenRequest.newBuilder().setActivationToken(tokenSent).build()
+      );
+    } else {
+      final ActivatePushTokenResponse ignored = authenticatedServiceStub().activatePushToken(
+        ActivatePushTokenRequest.newBuilder().build()
+      );
+    }
+
+    if (expectedSet) {
+      ArgumentCaptor<WebPushActivation> captor = ArgumentCaptor.forClass(WebPushActivation.class);
+      verify(device).setWebPushActivation(captor.capture());
+      assertEquals(true, captor.getValue().activated());
+      assertEquals(null, captor.getValue().activationToken());
+    } else {
+      verify(device, never()).setWebPushActivation(any());;
+    }
+    verify(device).setFetchesMessages(true);
+  }
+
+  private static Stream<Arguments> activatePushToken() {
+    return Stream.of(
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(true, null), "any", false),
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(true, null), null, false),
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(false, "valid"), null, false),
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(false, "valid"), "invalid", false),
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(false, "valid"), "invalid", false),
+        Arguments.of(Device.PRIMARY_ID, new WebPushActivation(false, "valid"), "valid", true),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(true, null), "any", false),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(true, null), null, false),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(false, "valid"), null, false),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(false, "valid"), "invalid", false),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(false, "valid"), "invalid", false),
+        Arguments.of((byte) (Device.PRIMARY_ID + 1), new WebPushActivation(false, "valid"), "valid", true)
     );
   }
 

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/APNSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/APNSenderTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.stubbing.Answer;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.Device;
 import org.whispersystems.textsecuregcm.tests.util.SynchronousExecutorService;
@@ -68,7 +69,7 @@ class APNSenderTest {
         .thenAnswer(
             (Answer) invocationOnMock -> new MockPushNotificationFuture<>(invocationOnMock.getArgument(0), response));
 
-    PushNotification pushNotification = new PushNotification(DESTINATION_DEVICE_TOKEN, PushNotification.TokenType.APN,
+    PushNotification pushNotification = new PushNotification(new PushToken.APN(DESTINATION_DEVICE_TOKEN),
         PushNotification.NotificationType.NOTIFICATION, null, destinationAccount, destinationDevice, urgent);
 
     final SendPushNotificationResult result = apnSender.sendNotification(pushNotification).join();
@@ -112,7 +113,7 @@ class APNSenderTest {
         .thenAnswer(
             (Answer) invocationOnMock -> new MockPushNotificationFuture<>(invocationOnMock.getArgument(0), response));
 
-    PushNotification pushNotification = new PushNotification(DESTINATION_DEVICE_TOKEN, PushNotification.TokenType.APN,
+    PushNotification pushNotification = new PushNotification(new PushToken.APN(DESTINATION_DEVICE_TOKEN),
         PushNotification.NotificationType.NOTIFICATION, null, destinationAccount, destinationDevice, true);
 
     when(destinationDevice.getApnId()).thenReturn(DESTINATION_DEVICE_TOKEN);
@@ -143,7 +144,7 @@ class APNSenderTest {
         .thenAnswer(
             (Answer) invocationOnMock -> new MockPushNotificationFuture<>(invocationOnMock.getArgument(0), response));
 
-    PushNotification pushNotification = new PushNotification(DESTINATION_DEVICE_TOKEN, PushNotification.TokenType.APN,
+    PushNotification pushNotification = new PushNotification(new PushToken.APN(DESTINATION_DEVICE_TOKEN),
         PushNotification.NotificationType.NOTIFICATION, null, destinationAccount, destinationDevice, true);
 
     final SendPushNotificationResult result = apnSender.sendNotification(pushNotification).join();
@@ -170,7 +171,7 @@ class APNSenderTest {
         .thenAnswer((Answer) invocationOnMock -> new MockPushNotificationFuture<>(invocationOnMock.getArgument(0),
             new IOException("lost connection")));
 
-    PushNotification pushNotification = new PushNotification(DESTINATION_DEVICE_TOKEN, PushNotification.TokenType.APN,
+    PushNotification pushNotification = new PushNotification(new PushToken.APN(DESTINATION_DEVICE_TOKEN),
         PushNotification.NotificationType.NOTIFICATION, null, destinationAccount, destinationDevice, true);
 
     assertThatThrownBy(() -> apnSender.sendNotification(pushNotification).join())

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/FcmSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/FcmSenderTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.tests.util.SynchronousExecutorService;
 
 class FcmSenderTest {
@@ -54,7 +55,7 @@ class FcmSenderTest {
 
   @Test
   void testSendMessage() {
-    final PushNotification pushNotification = new PushNotification("foo", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.FCM("foo"), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     final SettableApiFuture<String> sendFuture = SettableApiFuture.create();
     sendFuture.set("message-id");
@@ -71,7 +72,7 @@ class FcmSenderTest {
 
   @Test
   void testSendMessageRejected() {
-    final PushNotification pushNotification = new PushNotification("foo", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.FCM("foo"), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     final FirebaseMessagingException invalidArgumentException = mock(FirebaseMessagingException.class);
     when(invalidArgumentException.getMessagingErrorCode()).thenReturn(MessagingErrorCode.INVALID_ARGUMENT);
@@ -91,7 +92,7 @@ class FcmSenderTest {
 
   @Test
   void testSendMessageUnregistered() {
-    final PushNotification pushNotification = new PushNotification("foo", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.FCM("foo"), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     final FirebaseMessagingException unregisteredException = mock(FirebaseMessagingException.class);
     when(unregisteredException.getMessagingErrorCode()).thenReturn(MessagingErrorCode.UNREGISTERED);
@@ -111,7 +112,7 @@ class FcmSenderTest {
 
   @Test
   void testSendMessageException() {
-    final PushNotification pushNotification = new PushNotification("foo", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.FCM("foo"), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     final SettableApiFuture<String> sendFuture = SettableApiFuture.create();
     sendFuture.setException(new IOException());

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationManagerTest.java
@@ -140,7 +140,7 @@ class PushNotificationManagerTest {
     final PushToken<?> deviceToken = switch(tokenType) {
       case TokenType.APN -> new PushToken.APN("token");
       case TokenType.FCM -> new PushToken.FCM("token");
-      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub);
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub, true);
     };
 
     when(device.getId()).thenReturn(Device.PRIMARY_ID);
@@ -157,6 +157,7 @@ class PushNotificationManagerTest {
       }
       case TokenType.WEBPUSH -> {
         when(device.getWebPush()).thenReturn((WebPushSubscription) deviceToken.value());
+        when(device.getWebPushActivated()).thenReturn(true);
         when(webPushSender.sendNotification(any()))
             .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
       }
@@ -232,7 +233,7 @@ class PushNotificationManagerTest {
     final PushToken<?> deviceToken = switch(tokenType) {
       case TokenType.APN -> new PushToken.APN("token");
       case TokenType.FCM -> new PushToken.FCM("token");
-      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub);
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub, true);
     };
 
     final PushNotification pushNotification = new PushNotification(
@@ -337,7 +338,7 @@ class PushNotificationManagerTest {
     when(accountsManager.getByAccountIdentifier(aci)).thenReturn(Optional.of(account));
 
     final PushNotification pushNotification = new PushNotification(
-        new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+        new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
 
     when(webPushSender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.empty(), true, Optional.empty())));

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationManagerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationManagerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.net.HttpHeaders;
 import java.time.Instant;
 import java.util.Optional;
@@ -24,16 +25,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
+import org.whispersystems.textsecuregcm.push.PushNotification.TokenType;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
 import org.whispersystems.textsecuregcm.tests.util.AccountsHelper;
+import org.whispersystems.textsecuregcm.util.SystemMapper;
 
 class PushNotificationManagerTest {
 
   private AccountsManager accountsManager;
   private APNSender apnSender;
   private FcmSender fcmSender;
+  private WebPushSender webPushSender;
   private PushNotificationScheduler pushNotificationScheduler;
 
   private PushNotificationManager pushNotificationManager;
@@ -43,11 +48,12 @@ class PushNotificationManagerTest {
     accountsManager = mock(AccountsManager.class);
     apnSender = mock(APNSender.class);
     fcmSender = mock(FcmSender.class);
+    webPushSender = mock(WebPushSender.class);
     pushNotificationScheduler = mock(PushNotificationScheduler.class);
 
     AccountsHelper.setupMockUpdate(accountsManager);
 
-    pushNotificationManager = new PushNotificationManager(accountsManager, apnSender, fcmSender,
+    pushNotificationManager = new PushNotificationManager(accountsManager, apnSender, fcmSender, webPushSender,
         pushNotificationScheduler);
   }
 
@@ -56,16 +62,16 @@ class PushNotificationManagerTest {
     final Account account = mock(Account.class);
     final Device device = mock(Device.class);
 
-    final String deviceToken = "token";
+    final PushToken<?> deviceToken = new PushToken.FCM("token");
 
     when(device.getId()).thenReturn(Device.PRIMARY_ID);
-    when(device.getGcmId()).thenReturn(deviceToken);
+    when(device.getGcmId()).thenReturn((String) deviceToken.value());
     when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
 
       when(fcmSender.sendNotification(any()))
           .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
     pushNotificationManager.sendNewMessageNotification(account, Device.PRIMARY_ID, true);
-    verify(fcmSender).sendNotification(new PushNotification(deviceToken, PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, account, device, true));
+    verify(fcmSender).sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.NOTIFICATION, null, account, device, true));
   }
 
   @Test
@@ -73,10 +79,10 @@ class PushNotificationManagerTest {
     final Account account = mock(Account.class);
     final Device device = mock(Device.class);
 
-    final String deviceToken = "token";
+    final PushToken<?> deviceToken = new PushToken.FCM("token");
 
     when(device.getId()).thenReturn(Device.PRIMARY_ID);
-    when(device.getGcmId()).thenReturn(deviceToken);
+    when(device.getGcmId()).thenReturn((String) deviceToken.value());
     when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
 
     when(pushNotificationScheduler.scheduleBackgroundNotification(any(), any(), any()))
@@ -88,14 +94,14 @@ class PushNotificationManagerTest {
 
   @Test
   void sendRegistrationChallengeNotification() {
-    final String deviceToken = "token";
+    final PushToken<?> deviceToken = new PushToken.APN("token");
     final String challengeToken = "challenge";
 
     when(apnSender.sendNotification(any()))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
 
-    pushNotificationManager.sendRegistrationChallengeNotification(deviceToken, PushNotification.TokenType.APN, challengeToken);
-    verify(apnSender).sendNotification(new PushNotification(deviceToken, PushNotification.TokenType.APN, PushNotification.NotificationType.CHALLENGE, challengeToken, null, null, true));
+    pushNotificationManager.sendRegistrationChallengeNotification(deviceToken, challengeToken);
+    verify(apnSender).sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.CHALLENGE, challengeToken, null, null, true));
   }
 
   @Test
@@ -103,48 +109,76 @@ class PushNotificationManagerTest {
     final Account account = mock(Account.class);
     final Device device = mock(Device.class);
 
-    final String deviceToken = "token";
+    final PushToken<?> deviceToken = new PushToken.APN("token");
     final String challengeToken = "challenge";
 
     when(device.getId()).thenReturn(Device.PRIMARY_ID);
-    when(device.getApnId()).thenReturn(deviceToken);
+    when(device.getApnId()).thenReturn((String) deviceToken.value());
     when(account.getPrimaryDevice()).thenReturn(device);
 
     when(apnSender.sendNotification(any()))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
 
     pushNotificationManager.sendRateLimitChallengeNotification(account, challengeToken);
-    verify(apnSender).sendNotification(new PushNotification(deviceToken, PushNotification.TokenType.APN, PushNotification.NotificationType.RATE_LIMIT_CHALLENGE, challengeToken, account, device, true));
+    verify(apnSender).sendNotification(new PushNotification(deviceToken, PushNotification.NotificationType.RATE_LIMIT_CHALLENGE, challengeToken, account, device, true));
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void sendAttemptLoginNotification(final boolean isApn) throws NotPushRegisteredException {
+  @ValueSource(ints = {0, 1, 2})
+  void sendAttemptLoginNotification(final int tokenTypeOrd) throws NotPushRegisteredException, JsonProcessingException {
     final Account account = mock(Account.class);
     final Device device = mock(Device.class);
+    final TokenType tokenType = TokenType.values()[tokenTypeOrd];
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
 
-    final String deviceToken = "token";
+    final PushToken<?> deviceToken = switch(tokenType) {
+      case TokenType.APN -> new PushToken.APN("token");
+      case TokenType.FCM -> new PushToken.FCM("token");
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub);
+    };
 
     when(device.getId()).thenReturn(Device.PRIMARY_ID);
-    if (isApn) {
-      when(device.getApnId()).thenReturn(deviceToken);
-      when(apnSender.sendNotification(any()))
-          .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
-    } else {
-      when(device.getGcmId()).thenReturn(deviceToken);
-      when(fcmSender.sendNotification(any()))
-          .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
+    switch (tokenType) {
+      case TokenType.APN -> {
+        when(device.getApnId()).thenReturn((String) deviceToken.value());
+        when(apnSender.sendNotification(any()))
+            .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
+      }
+      case TokenType.FCM -> {
+        when(device.getGcmId()).thenReturn((String) deviceToken.value());
+        when(fcmSender.sendNotification(any()))
+            .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
+      }
+      case TokenType.WEBPUSH -> {
+        when(device.getWebPush()).thenReturn((WebPushSubscription) deviceToken.value());
+        when(webPushSender.sendNotification(any()))
+            .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
+      }
     }
+
     when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
 
     pushNotificationManager.sendAttemptLoginNotification(account, "someContext");
 
-    if (isApn){
-      verify(apnSender).sendNotification(new PushNotification(deviceToken, PushNotification.TokenType.APN,
-          PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, "someContext", account, device, true));
-    } else {
-      verify(fcmSender, times(1)).sendNotification(new PushNotification(deviceToken, PushNotification.TokenType.FCM,
-          PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, "someContext", account, device, true));
+    switch (tokenType) {
+      case TokenType.APN -> {
+        verify(apnSender).sendNotification(new PushNotification(deviceToken,
+            PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, "someContext", account, device, true));
+      }
+      case TokenType.FCM -> {
+        verify(fcmSender, times(1)).sendNotification(new PushNotification(deviceToken,
+            PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, "someContext", account, device, true));
+      }
+      case TokenType.WEBPUSH -> {
+        verify(webPushSender, times(1)).sendNotification(new PushNotification(deviceToken,
+            PushNotification.NotificationType.ATTEMPT_LOGIN_NOTIFICATION_HIGH_PRIORITY, "someContext", account, device, true));
+      }
     }
   }
 
@@ -157,7 +191,7 @@ class PushNotificationManagerTest {
     when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
 
     final PushNotification pushNotification = new PushNotification(
-        "token", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+        new PushToken.FCM("token"), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
 
     when(fcmSender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
@@ -166,6 +200,7 @@ class PushNotificationManagerTest {
 
     verify(fcmSender).sendNotification(pushNotification);
     verifyNoInteractions(apnSender);
+    verifyNoInteractions(webPushSender);
     verify(accountsManager, never()).updateDevice(eq(account), eq(Device.PRIMARY_ID), any());
     verify(device, never()).setGcmId(any());
     verifyNoInteractions(pushNotificationScheduler);
@@ -174,7 +209,8 @@ class PushNotificationManagerTest {
   @CartesianTest
   void testSendOrScheduleNotification(
       @CartesianTest.Enum(PushNotification.TokenType.class) PushNotification.TokenType tokenType,
-      @CartesianTest.Values(booleans = {false, true}) final boolean urgent) {
+      @CartesianTest.Values(booleans = {false, true}) final boolean urgent
+    ) throws JsonProcessingException {
 
     final boolean expectSchedule = !urgent;
 
@@ -186,12 +222,26 @@ class PushNotificationManagerTest {
     when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
     when(account.getUuid()).thenReturn(aci);
 
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushToken<?> deviceToken = switch(tokenType) {
+      case TokenType.APN -> new PushToken.APN("token");
+      case TokenType.FCM -> new PushToken.FCM("token");
+      case TokenType.WEBPUSH -> new PushToken.WEBPUSH(webPushSub);
+    };
+
     final PushNotification pushNotification = new PushNotification(
-        "token", tokenType, PushNotification.NotificationType.NOTIFICATION, null, account, device, urgent);
+       deviceToken, PushNotification.NotificationType.NOTIFICATION, null, account, device, urgent);
 
     final PushNotificationSender sender = switch (tokenType) {
       case FCM -> fcmSender;
       case APN -> apnSender;
+      case WEBPUSH -> webPushSender;
     };
     when(sender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
@@ -224,7 +274,7 @@ class PushNotificationManagerTest {
     when(accountsManager.getByAccountIdentifier(aci)).thenReturn(Optional.of(account));
 
     final PushNotification pushNotification = new PushNotification(
-        "token", PushNotification.TokenType.FCM, PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+        new PushToken.FCM("token"), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
 
     when(fcmSender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.empty(), true, Optional.empty())));
@@ -234,6 +284,7 @@ class PushNotificationManagerTest {
     verify(accountsManager).updateDevice(eq(account), eq(Device.PRIMARY_ID), any());
     verify(device).setGcmId(null);
     verifyNoInteractions(apnSender);
+    verifyNoInteractions(webPushSender);
     verifyNoInteractions(pushNotificationScheduler);
   }
 
@@ -249,7 +300,7 @@ class PushNotificationManagerTest {
     when(accountsManager.getByAccountIdentifier(aci)).thenReturn(Optional.of(account));
 
     final PushNotification pushNotification = new PushNotification(
-        "token", PushNotification.TokenType.APN, PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+        new PushToken.APN("token"), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
 
     when(apnSender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.empty(), true, Optional.empty())));
@@ -260,9 +311,44 @@ class PushNotificationManagerTest {
     pushNotificationManager.sendNotification(pushNotification);
 
     verifyNoInteractions(fcmSender);
+    verifyNoInteractions(webPushSender);
     verify(accountsManager).updateDevice(eq(account), eq(Device.PRIMARY_ID), any());
     verify(device).setApnId(null);
     verify(pushNotificationScheduler).cancelScheduledNotifications(account, device);
+  }
+
+  @Test
+  void testSendNotificationUnregisteredWebPush() throws JsonProcessingException {
+    final Account account = mock(Account.class);
+    final Device device = mock(Device.class);
+    final UUID aci = UUID.randomUUID();
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+
+    when(device.getId()).thenReturn(Device.PRIMARY_ID);
+    when(device.getWebPush()).thenReturn(webPushSub);
+    when(account.getDevice(Device.PRIMARY_ID)).thenReturn(Optional.of(device));
+    when(account.getUuid()).thenReturn(aci);
+    when(accountsManager.getByAccountIdentifier(aci)).thenReturn(Optional.of(account));
+
+    final PushNotification pushNotification = new PushNotification(
+        new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+
+    when(webPushSender.sendNotification(pushNotification))
+        .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.empty(), true, Optional.empty())));
+
+    pushNotificationManager.sendNotification(pushNotification);
+
+    verify(accountsManager).updateDevice(eq(account), eq(Device.PRIMARY_ID), any());
+    verify(device).setWebPush(null);
+    verifyNoInteractions(fcmSender);
+    verifyNoInteractions(apnSender);
+    verifyNoInteractions(pushNotificationScheduler);
   }
 
   @Test
@@ -280,7 +366,7 @@ class PushNotificationManagerTest {
     when(accountsManager.getByAccountIdentifier(aci)).thenReturn(Optional.of(account));
 
     final PushNotification pushNotification = new PushNotification(
-        "token", PushNotification.TokenType.APN, PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
+        new PushToken.APN("token"), PushNotification.NotificationType.NOTIFICATION, null, account, device, true);
 
     when(apnSender.sendNotification(pushNotification))
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(false, Optional.empty(), true, Optional.of(tokenTimestamp.minusSeconds(60)))));
@@ -291,6 +377,7 @@ class PushNotificationManagerTest {
     pushNotificationManager.sendNotification(pushNotification);
 
     verifyNoInteractions(fcmSender);
+    verifyNoInteractions(webPushSender);
     verify(accountsManager, never()).updateDevice(eq(account), eq(Device.PRIMARY_ID), any());
     verify(device, never()).setApnId(any());
     verify(pushNotificationScheduler, never()).cancelScheduledNotifications(account, device);

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationSchedulerTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/PushNotificationSchedulerTest.java
@@ -38,6 +38,7 @@ import org.whispersystems.textsecuregcm.redis.RedisClusterExtension;
 import org.whispersystems.textsecuregcm.storage.Account;
 import org.whispersystems.textsecuregcm.storage.AccountsManager;
 import org.whispersystems.textsecuregcm.storage.Device;
+import org.whispersystems.textsecuregcm.util.SystemMapper;
 import org.whispersystems.textsecuregcm.util.TestClock;
 
 class PushNotificationSchedulerTest {
@@ -50,6 +51,7 @@ class PushNotificationSchedulerTest {
 
   private APNSender apnSender;
   private FcmSender fcmSender;
+  private WebPushSender webPushSender;
   private TestClock clock;
 
   private PushNotificationScheduler pushNotificationScheduler;
@@ -59,6 +61,7 @@ class PushNotificationSchedulerTest {
   private static final byte DEVICE_ID = 1;
   private static final String APN_ID = RandomStringUtils.secure().nextAlphanumeric(32);
   private static final String GCM_ID = RandomStringUtils.secure().nextAlphanumeric(32);
+  private WebPushSubscription WEB_PUSH_SUB;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -80,8 +83,17 @@ class PushNotificationSchedulerTest {
     when(accountsManager.getByAccountIdentifierAsync(ACCOUNT_UUID))
         .thenReturn(CompletableFuture.completedFuture(Optional.of(account)));
 
+    WEB_PUSH_SUB =  SystemMapper.jsonMapper().readValue("""
+      {
+        "endpoint": "https://domain.tld/random1",
+        "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+        "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+      }
+    """, WebPushSubscription.class);
     apnSender = mock(APNSender.class);
     fcmSender = mock(FcmSender.class);
+    webPushSender = mock(WebPushSender.class);
+
     clock = TestClock.now();
 
     when(apnSender.sendNotification(any()))
@@ -91,7 +103,7 @@ class PushNotificationSchedulerTest {
         .thenReturn(CompletableFuture.completedFuture(new SendPushNotificationResult(true, Optional.empty(), false, Optional.empty())));
 
     pushNotificationScheduler = new PushNotificationScheduler(REDIS_CLUSTER_EXTENSION.getRedisCluster(),
-        apnSender, fcmSender, accountsManager, clock, 1, 1, mock(ScheduledExecutorService.class));
+        apnSender, fcmSender, webPushSender, accountsManager, clock, 1, 1, mock(ScheduledExecutorService.class));
   }
 
   @ParameterizedTest
@@ -172,6 +184,7 @@ class PushNotificationSchedulerTest {
     verify(switch (tokenType) {
       case FCM -> fcmSender;
       case APN -> apnSender;
+      case WEBPUSH -> webPushSender;
     }).sendNotification(notificationCaptor.capture());
 
     final PushNotification pushNotification = notificationCaptor.getValue();
@@ -180,7 +193,8 @@ class PushNotificationSchedulerTest {
     assertEquals(switch (tokenType) {
       case FCM -> GCM_ID;
       case APN -> APN_ID;
-    }, pushNotification.deviceToken());
+      case WEBPUSH -> WEB_PUSH_SUB;
+    }, pushNotification.pushToken().value());
     assertEquals(account, pushNotification.destination());
     assertEquals(device, pushNotification.destinationDevice());
     assertEquals(PushNotification.NotificationType.NOTIFICATION, pushNotification.notificationType());
@@ -267,7 +281,7 @@ class PushNotificationSchedulerTest {
 
     final AccountsManager accountsManager = mock(AccountsManager.class);
 
-    pushNotificationScheduler = new PushNotificationScheduler(redisCluster, apnSender, fcmSender,
+    pushNotificationScheduler = new PushNotificationScheduler(redisCluster, apnSender, fcmSender, webPushSender,
         accountsManager, dedicatedThreadCount, 1, mock(ScheduledExecutorService.class));
 
     pushNotificationScheduler.start();

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -17,9 +17,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.whispersystems.textsecuregcm.configuration.WebPushConfiguration;
+import org.whispersystems.textsecuregcm.configuration.secrets.SecretBytes;
 import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
 import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
 import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
@@ -48,14 +51,18 @@ class WebPushSenderTest {
   private ExecutorService executorService;
   private FaultTolerantHttpClient httpClient;
   private FaultTolerantRedisClusterClient redisClient;
+  private WebPushConfiguration config;
   private WebPushSender webPushSender;
 
+  private static final String VAPID_PRIVATE_KEY = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8dRIiQwMkW/hdtdytU4NJmQWDjUTOv3ZV/nDQVGHGy2hRANCAATpV1b2ETFP0CCL6woRsdG0SnilqV7NMoiisocq5P/xl0GO8T97N3w7a/b4oWNkWKvxJ1hN5Q75tZauC0sXHOS5";
+
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() throws Exception {
     executorService = new SynchronousExecutorService();
     httpClient = mock(FaultTolerantHttpClient.class);
     redisClient = mock(FaultTolerantRedisClusterClient.class);
-    webPushSender = new WebPushSender(executorService, redisClient, httpClient);
+    config = new WebPushConfiguration(new SecretBytes(Base64.getDecoder().decode(VAPID_PRIVATE_KEY)));
+    webPushSender = new WebPushSender(executorService, redisClient, config.vapidStaticKeyPair(), httpClient);
   }
 
   @AfterEach
@@ -215,5 +222,13 @@ class WebPushSenderTest {
       return arg.apply(cluster);
     });
     return cmd;
+  }
+
+  @Test
+  void testVapidHeader() throws GeneralSecurityException, JsonProcessingException {
+    final String vapidHeader = WebPushSender.genAuthorization(config.vapidStaticKeyPair(), "https://domain.tld", "mailto:mail@example.localhost", 1000000);
+    // Replace URL-safe Base64 encoded signature, as it changes everytime. That's enough to test the header is in the good format
+    final String toCompare = vapidHeader.replaceAll("\\.[A-Za-z0-9-_]+,", ".AAAABBBBCCCCDDDD,");
+    assertEquals("vapid t=eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJhdWQiOiJodHRwczovL2RvbWFpbi50bGQiLCJzdWIiOiJtYWlsdG86bWFpbEBleGFtcGxlLmxvY2FsaG9zdCIsImV4cCI6MTAwMDkwMH0.AAAABBBBCCCCDDDD,k=BOlXVvYRMU_QIIvrChGx0bRKeKWpXs0yiKKyhyrk__GXQY7xP3s3fDtr9vihY2RYq_EnWE3lDvm1lq4LSxcc5Lk", toCompare);
   }
 }

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -10,16 +10,22 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,22 +33,29 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
 import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
+import org.whispersystems.textsecuregcm.redis.FaultTolerantRedisClusterClient;
 import org.whispersystems.textsecuregcm.tests.util.SynchronousExecutorService;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.lettuce.core.api.sync.RedisStringCommands;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+
 class WebPushSenderTest {
 
   private ExecutorService executorService;
   private FaultTolerantHttpClient httpClient;
+  private FaultTolerantRedisClusterClient redisClient;
   private WebPushSender webPushSender;
 
   @BeforeEach
   void setUp() throws IOException {
     executorService = new SynchronousExecutorService();
     httpClient = mock(FaultTolerantHttpClient.class);
-    webPushSender = new WebPushSender(executorService, httpClient);
+    redisClient = mock(FaultTolerantRedisClusterClient.class);
+    webPushSender = new WebPushSender(executorService, redisClient, httpClient);
   }
 
   @AfterEach
@@ -64,6 +77,8 @@ class WebPushSenderTest {
       """, WebPushSubscription.class);
     final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
+    // Redis must be mocked before sendNotification
+    final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
     final HttpResponse<byte[]> response = mock(HttpResponse.class);
     when(response.statusCode()).thenReturn(201);
 
@@ -73,6 +88,7 @@ class WebPushSenderTest {
     final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
 
     verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    verify(cmd, never()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
     assertTrue(result.accepted());
     assertTrue(result.errorCode().isEmpty());
     assertFalse(result.unregistered());
@@ -89,6 +105,8 @@ class WebPushSenderTest {
       """, WebPushSubscription.class);
     final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
+    // Redis must be mocked before sendNotification
+    final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
     final HttpResponse<byte[]> response = mock(HttpResponse.class);
     when(response.statusCode()).thenReturn(500);
 
@@ -98,6 +116,7 @@ class WebPushSenderTest {
     final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
 
     verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    verify(cmd, never()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
     assertFalse(result.accepted());
     assertEquals(Optional.of("500"), result.errorCode());
     assertFalse(result.unregistered());
@@ -115,6 +134,8 @@ class WebPushSenderTest {
       """, WebPushSubscription.class);
     final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
+    // Redis must be mocked before sendNotification
+    final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
     final HttpResponse<byte[]> response = mock(HttpResponse.class);
     when(response.statusCode()).thenReturn(statusCode);
 
@@ -125,10 +146,74 @@ class WebPushSenderTest {
     final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
 
     verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    verify(cmd, never()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
     assertFalse(result.accepted());
     assertEquals(Optional.of(String.valueOf(statusCode)), result.errorCode());
     assertTrue(result.unregistered());
   }
 
-  // TODO test 429
+  @Test
+  void testSendMessageRateLimited() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    // Redis must be mocked before sendNotification
+    final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
+    final HttpResponse<byte[]> response = mock(HttpResponse.class);
+    final HttpHeaders headers = mock(HttpHeaders.class);
+    when(headers.firstValue(any())).thenReturn(Optional.empty());
+    when(response.statusCode()).thenReturn(429);
+    when(response.headers()).thenReturn(headers);
+
+    final CompletableFuture<HttpResponse<byte[]>> sendFuture = CompletableFuture.completedFuture(response);
+    when(httpClient.sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()))).thenReturn(sendFuture);
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    verify(cmd, atLeastOnce()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
+    assertFalse(result.accepted());
+    assertEquals(Optional.of("Rate limited"), result.errorCode());
+    assertFalse(result.unregistered());
+  }
+
+  @Test
+  void testSendMessageAlreadyRateLimited() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
+    when(cmd.get(any())).thenReturn(WebPushSender.RATE_LIMITED);
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verifyNoInteractions(httpClient);
+    verify(cmd, never()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
+    assertFalse(result.accepted());
+    assertEquals(Optional.of("Rate limited"), result.errorCode());
+    assertFalse(result.unregistered());
+  }
+
+  RedisAdvancedClusterCommands<String, String> mockRedis(FaultTolerantRedisClusterClient redisClient) {
+    final RedisAdvancedClusterCommands<String, String> cmd = mock(RedisAdvancedClusterCommands.class);
+    final StatefulRedisClusterConnection cluster = mock(StatefulRedisClusterConnection.class);
+    when(cluster.sync()).thenReturn(cmd);
+    when(redisClient.withCluster(any())).then( inv -> {
+      final Function<StatefulRedisClusterConnection<String, String>, String> arg = inv.getArgument(0);
+      return arg.apply(cluster);
+    });
+    return cmd;
+  }
 }

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -88,7 +88,7 @@ class WebPushSenderTest {
           "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
         }
       """, WebPushSubscription.class);
-    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     // Redis must be mocked before sendNotification
     final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
@@ -108,6 +108,25 @@ class WebPushSenderTest {
   }
 
   @Test
+  void testSendMessageInactive() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, false), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verifyNoInteractions(httpClient);
+    assertFalse(result.accepted());
+    assertFalse(result.errorCode().isEmpty());
+    assertFalse(result.unregistered());
+  }
+
+  @Test
   void testSendMessageRejected() throws JsonProcessingException {
     final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
         {
@@ -116,7 +135,7 @@ class WebPushSenderTest {
           "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
         }
       """, WebPushSubscription.class);
-    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     // Redis must be mocked before sendNotification
     final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
@@ -145,7 +164,7 @@ class WebPushSenderTest {
           "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
         }
       """, WebPushSubscription.class);
-    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     // Redis must be mocked before sendNotification
     final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
@@ -174,7 +193,7 @@ class WebPushSenderTest {
           "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
         }
       """, WebPushSubscription.class);
-    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     // Redis must be mocked before sendNotification
     final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
@@ -205,7 +224,7 @@ class WebPushSenderTest {
           "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
         }
       """, WebPushSubscription.class);
-    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub, true), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
 
     final RedisStringCommands<String, String> cmd = mockRedis(redisClient);
     when(cmd.get(any())).thenReturn(WebPushSender.RATE_LIMITED);

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -61,8 +61,14 @@ class WebPushSenderTest {
     executorService = new SynchronousExecutorService();
     httpClient = mock(FaultTolerantHttpClient.class);
     redisClient = mock(FaultTolerantRedisClusterClient.class);
-    config = new WebPushConfiguration(new SecretBytes(Base64.getDecoder().decode(VAPID_PRIVATE_KEY)));
-    webPushSender = new WebPushSender(executorService, redisClient, config.vapidStaticKeyPair(), httpClient);
+    config = new WebPushConfiguration(new SecretBytes(Base64.getDecoder().decode(VAPID_PRIVATE_KEY)), "mailto:test@example.tld");
+    webPushSender = new WebPushSender(
+      executorService,
+      redisClient,
+      config.vapidStaticKeyPair(),
+      config.vapidSub(),
+      httpClient
+    );
   }
 
   @AfterEach

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -209,7 +209,7 @@ class WebPushSenderTest {
     final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
 
     verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
-    verify(cmd, atLeastOnce()).set(any(), eq(WebPushSender.RATE_LIMITED), any());
+    verify(cmd, atLeastOnce()).set(eq("WP_END::https://domain.tld/random1"), eq(WebPushSender.RATE_LIMITED), any());
     assertFalse(result.accepted());
     assertEquals(Optional.of("Rate limited"), result.errorCode());
     assertFalse(result.unregistered());

--- a/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/push/WebPushSenderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2013 Signal Messenger, LLC
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+package org.whispersystems.textsecuregcm.push;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.whispersystems.textsecuregcm.http.FaultTolerantHttpClient;
+import org.whispersystems.textsecuregcm.push.PushNotification.PushToken;
+import org.whispersystems.textsecuregcm.tests.util.SynchronousExecutorService;
+import org.whispersystems.textsecuregcm.util.SystemMapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+class WebPushSenderTest {
+
+  private ExecutorService executorService;
+  private FaultTolerantHttpClient httpClient;
+  private WebPushSender webPushSender;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    executorService = new SynchronousExecutorService();
+    httpClient = mock(FaultTolerantHttpClient.class);
+    webPushSender = new WebPushSender(executorService, httpClient);
+  }
+
+  @AfterEach
+  void tearDown() throws InterruptedException {
+    executorService.shutdown();
+
+    //noinspection ResultOfMethodCallIgnored
+    executorService.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testSendMessage() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    final HttpResponse<byte[]> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(201);
+
+    final CompletableFuture<HttpResponse<byte[]>> sendFuture = CompletableFuture.completedFuture(response);
+    when(httpClient.sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()))).thenReturn(sendFuture);
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    assertTrue(result.accepted());
+    assertTrue(result.errorCode().isEmpty());
+    assertFalse(result.unregistered());
+  }
+
+  @Test
+  void testSendMessageRejected() throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    final HttpResponse<byte[]> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(500);
+
+    final CompletableFuture<HttpResponse<byte[]>> sendFuture = CompletableFuture.completedFuture(response);
+    when(httpClient.sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()))).thenReturn(sendFuture);
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    assertFalse(result.accepted());
+    assertEquals(Optional.of("500"), result.errorCode());
+    assertFalse(result.unregistered());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {404, 403, 401, 410})
+  void testSendMessageUnregistered(final int statusCode) throws JsonProcessingException {
+    final WebPushSubscription webPushSub = SystemMapper.jsonMapper().readValue("""
+        {
+          "endpoint": "https://domain.tld/random1",
+          "auth": "BTBZMqHH6r4Tts7J_aSIgg",
+          "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+        }
+      """, WebPushSubscription.class);
+    final PushNotification pushNotification = new PushNotification(new PushToken.WEBPUSH(webPushSub), PushNotification.NotificationType.NOTIFICATION, null, null, null, true);
+
+    final HttpResponse<byte[]> response = mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(statusCode);
+
+    final CompletableFuture<HttpResponse<byte[]>> sendFuture = CompletableFuture.completedFuture(response);
+    when(httpClient.sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()))).thenReturn(sendFuture);
+
+
+    final SendPushNotificationResult result = webPushSender.sendNotification(pushNotification).join();
+
+    verify(httpClient).sendAsync(any(), eq(HttpResponse.BodyHandlers.ofByteArray()));
+    assertFalse(result.accepted());
+    assertEquals(Optional.of(String.valueOf(statusCode)), result.errorCode());
+    assertTrue(result.unregistered());
+  }
+
+  // TODO test 429
+}

--- a/service/src/test/java/org/whispersystems/textsecuregcm/storage/DeviceTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/storage/DeviceTest.java
@@ -5,15 +5,28 @@
 
 package org.whispersystems.textsecuregcm.storage;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Set;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.dropwizard.jersey.validation.Validators;
+import jakarta.validation.ConstraintViolation;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.whispersystems.textsecuregcm.push.WebPushSubscription;
 import org.whispersystems.textsecuregcm.util.SystemMapper;
 
 class DeviceTest {
@@ -67,4 +80,73 @@ class DeviceTest {
     }
   }
 
+  @Test
+  void deserializeWebPushSub() throws JsonProcessingException, URISyntaxException {
+    {
+      final String endpoint = "https://domain.tld/random1";
+      final String b64Auth = "BTBZMqHH6r4Tts7J_aSIgg";
+      final byte[] auth = Base64.getUrlDecoder().decode(b64Auth);
+      final Device device = SystemMapper.jsonMapper().readValue(String.format("""
+          {
+            "webPush": {
+              "endpoint": "%s",
+              "auth": "%s",
+              "publicKey": "BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4"
+            }
+          }
+          """, endpoint, b64Auth), Device.class);
+
+      WebPushSubscription webpush = device.getWebPush();
+      final Set<ConstraintViolation<Device>> constraintViolations = Validators.newValidator().validate(device);
+      assertTrue(constraintViolations.isEmpty(),
+          "Device should pass validation");
+      assertNotNull(webpush,
+          "Device deserialization should populate webPush");
+      assertEquals(new URI(endpoint), webpush.endpoint(),
+          "Endpoint populated from device deserialization doesn't match expectation");
+      assertArrayEquals(auth, webpush.userAuth(),
+          "Auth populated from device deserialization doesn't match expectation");
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      // Invalid endpoints
+      "\"http://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "\"https:///random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "\"unix:///domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "null, \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "0, \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "[], \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "[\"https://domain.tld.random1\"], \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      // Invalid auth
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J/aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgkFBQUE\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4\"",
+      // Invalid publicKey
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs4\"",
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw5BQUFB\"",
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"",
+      "\"https://domain.tld/random1\", \"BTBZMqHH6r4Tts7J_aSIgg\", \"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXGyvs3942BVGq8e0PTNNmwRzr5VX4m8t7GGpTM5FzFo7OLr4BhZe9MEebhuPI-OztV3ylkYfpJGmQ22ggCLDg\"",
+  })
+  void deserializeInvalidWebPushSub(String endpoint, String b64Auth, String publicKey) {
+    {
+      try {
+        final Device device = SystemMapper.jsonMapper().readValue(String.format("""
+          {
+            "webPush": {
+              "endpoint": %s,
+              "auth": %s,
+              "publicKey": %s
+            }
+          }
+          """, endpoint, b64Auth, publicKey), Device.class);
+          final Set<ConstraintViolation<Device>> constraintViolations = Validators.newValidator().validate(device);
+          assertFalse(constraintViolations.isEmpty(),
+              "Invalid device should not pass validation");
+      } catch (JsonProcessingException e) {
+        return;
+      }
+    }
+  }
 }

--- a/service/src/test/java/org/whispersystems/textsecuregcm/workers/FinishPushNotificationExperimentCommandTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/workers/FinishPushNotificationExperimentCommandTest.java
@@ -74,6 +74,7 @@ class FinishPushNotificationExperimentCommandTest {
         null,
         null,
         null,
+        null,
         pushNotificationExperimentSamples,
         null,
         null,

--- a/service/src/test/java/org/whispersystems/textsecuregcm/workers/NotifyIdleDevicesCommandTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/workers/NotifyIdleDevicesCommandTest.java
@@ -68,6 +68,7 @@ class NotifyIdleDevicesCommandTest {
           null,
           null,
           null,
+          null,
           null);
 
       this.idleDeviceNotificationScheduler = idleDeviceNotificationScheduler;

--- a/service/src/test/java/org/whispersystems/textsecuregcm/workers/RegenerateSecondaryDynamoDbTableDataCommandTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/workers/RegenerateSecondaryDynamoDbTableDataCommandTest.java
@@ -53,6 +53,7 @@ class RegenerateSecondaryDynamoDbTableDataCommandTest {
           null,
           null,
           null,
+          null,
           dynamoDbRecoveryManager);
 
       namespace = new Namespace(Map.of(

--- a/service/src/test/java/org/whispersystems/textsecuregcm/workers/StartPushNotificationExperimentCommandTest.java
+++ b/service/src/test/java/org/whispersystems/textsecuregcm/workers/StartPushNotificationExperimentCommandTest.java
@@ -63,6 +63,7 @@ class StartPushNotificationExperimentCommandTest {
           null,
           null,
           null,
+          null,
           pushNotificationExperimentSamples,
           null,
           null,

--- a/service/src/test/resources/config/test-secrets-bundle.yml
+++ b/service/src/test/resources/config/test-secrets-bundle.yml
@@ -177,3 +177,11 @@ tlsKeyStore.password: unset
 # Corresponding public key: cYUAFtkWK/4x3AfW/yw7qgIo/mQUaRSWaPolGQkiL14=
 noiseTunnel.noiseStaticPrivateKey: qK5FD9WmuhoLPsS/Z4swcZkwDn9OpeM5ZmcEVMpEQ24=
 noiseTunnel.recognizedProxySecret: ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789AAAAAAA
+
+# To generate a key: openssl ecparam -name prime256v1 -genkey -noout | openssl pkcs8 -topk8 -outform DER -nocrypt | base64 -w0
+#
+# To get the public key (always starts with \x04): openssl ec -pubout -outform DER | tail -c +27 | basenc --base64url -w0
+#
+# The below private key was generated exclusively for testing purposes. Do not use it in any other context.
+# Associated public key: BOlXVvYRMU_QIIvrChGx0bRKeKWpXs0yiKKyhyrk__GXQY7xP3s3fDtr9vihY2RYq_EnWE3lDvm1lq4LSxcc5Lk
+webPush.vapidStaticPrivateKey: MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8dRIiQwMkW/hdtdytU4NJmQWDjUTOv3ZV/nDQVGHGy2hRANCAATpV1b2ETFP0CCL6woRsdG0SnilqV7NMoiisocq5P/xl0GO8T97N3w7a/b4oWNkWKvxJ1hN5Q75tZauC0sXHOS5

--- a/service/src/test/resources/config/test.yml
+++ b/service/src/test/resources/config/test.yml
@@ -519,7 +519,6 @@ turn:
       - turn:%s:80?transport=tcp
       - turns:%s:443?transport=tcp
     hostname: turn.example.com
-    numHttpClients: 1
 
 linkDevice:
   secret: secret://linkDevice.secret

--- a/service/src/test/resources/config/test.yml
+++ b/service/src/test/resources/config/test.yml
@@ -529,6 +529,9 @@ noiseTunnel:
   noiseStaticPrivateKey: secret://noiseTunnel.noiseStaticPrivateKey
   recognizedProxySecret: secret://noiseTunnel.recognizedProxySecret
 
+webPush:
+  vapidStaticPrivateKey: secret://webPush.vapidStaticPrivateKey
+
 externalRequestFilter:
   grpcMethods:
     - com.example.grpc.ExampleService/exampleMethod

--- a/service/src/test/resources/config/test.yml
+++ b/service/src/test/resources/config/test.yml
@@ -530,6 +530,9 @@ noiseTunnel:
   recognizedProxySecret: secret://noiseTunnel.recognizedProxySecret
 
 webPush:
+  # vapidSub can be an https:// url or a mailto: url
+  # vapidSub: mailto:contact@example.com
+  vapidSub: https://github.com/mollyim/flatline-platform/issues
   vapidStaticPrivateKey: secret://webPush.vapidStaticPrivateKey
 
 externalRequestFilter:


### PR DESCRIPTION
This PR adds webpush support to the server, and the tests that go with it.

I have not yet tested with a real client, I need to work on the client first.

But I've tested with a push notification to Firefox using the [webPushDataTestPage](https://mozilla-services.github.io/WebPushDataTestPage/?restricted=1), authorized with VAPID, sent from a test. The notification is correctly received and decrypted.

Most of the changes are additional functions/classes. But:
- One important change has been made to `PushNotification`, has the pair `String deviceToken, TokenType tokenType` doesn't work with Web Push: the *deviceToken* isn't a String.
- `device.proto` has a new `token_request` kind, that may conflict with signal at some point (if they don't want webpush support, and choose to support another protocol)
- I've removed redundant code to get the device push token